### PR TITLE
Fix duplicate items in Quickstart docs

### DIFF
--- a/Docs/quickstart.md
+++ b/Docs/quickstart.md
@@ -20,7 +20,6 @@ Key folders and scripts include:
 - `rpscrape/` – scraper for racecards and results.
 - ROI tracking scripts (e.g., `roi/roi_tracker_advised.py`, `roi/send_daily_roi_summary.py`) and `roi/run_roi_pipeline.sh` send performance updates via Telegram.
 - `logs/` – organized logs for inference, ROI and dispatch processes.
-- `logs/` – organized logs for inference, ROI and dispatch processes.
 - `predictions/` – daily output tips and summaries.
 - Core scripts such as `core/run_pipeline_with_venv.sh`, `core/fetch_betfair_odds.py`, and `core/dispatch_tips.py` drive the daily pipeline.
 - `cli/tmcli.py` – command-line helper with `pipeline`, `roi`, `sniper` and `healthcheck` commands.
@@ -58,7 +57,6 @@ These times are detailed in `Docs/monster_overview.md`.
 1. **Read through `Docs/monster_overview.md`** to understand the full pipeline and feature set.
 2. **Consult `Docs/ops.md`** for cron schedules and log locations.
 3. Explore the training (`core/train_model_v6.py`) and inference (`core/run_inference_and_select_top1.py`) scripts to see how predictions are generated.
-4. Review the ROI scripts (e.g., `roi/roi_tracker_advised.py`) and `roi/run_roi_pipeline.sh` to understand profit tracking.
 4. Review the ROI scripts (e.g., `roi/roi_tracker_advised.py`) and `roi/run_roi_pipeline.sh` to understand profit tracking.
 5. Check the TODO lists in `Docs/monster_todo.md` and `Docs/TIPPING_MONSTER_ROI_TODO.md` for future work items.
 6. Run `./dev-check.sh` followed by `make test` to verify your setup.


### PR DESCRIPTION
## Summary
- remove duplicate `logs/` bullet in Quickstart
- remove repeated step in the newcomer checklist

## Testing
- `make test` *(fails: dev-check.sh missing)*
- `pytest -q` *(fails: missing pandas)*

------
https://chatgpt.com/codex/tasks/task_e_684495c87cfc8324aee31ac0073ffe73