### PR TITLE
Update docs on running inference

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -52,3 +52,12 @@ python dispatch_all_tips.py --date 2025-06-07 --telegram --batch-size 10
 
 Built by Paul. Maintained by Monster. Improved by chaos. 🧠🐎.
 
+### Running Inference
+
+Run inference scripts from the repository root. Example:
+
+```bash
+python core/run_inference_and_select_top1.py
+```
+Running this command inside `core/` will fail with `ModuleNotFoundError` unless `PYTHONPATH=..` is configured.
+

--- a/Docs/quickstart.md
+++ b/Docs/quickstart.md
@@ -47,6 +47,12 @@ These times are detailed in `Docs/monster_overview.md`.
 - **Training:** `core/train_model_v6.py` and `core/train_modelv7.py` load historical data and produce an XGBoost model.
 - **Model Comparison:** `core/compare_model_v6_v7.py` trains both versions side by side and logs confidence deltas.
 - **Inference:** `core/run_inference_and_select_top1.py` downloads the latest model, predicts on flattened racecards and uploads predictions.
+- **Important:** run this script from the **repository root**:
+
+```bash
+python core/run_inference_and_select_top1.py
+```
+Running it while inside `core/` triggers a `ModuleNotFoundError` unless you set `PYTHONPATH=..`.
 - **Odds Integration:** `core/fetch_betfair_odds.py` grabs odds snapshots; `core/merge_odds_into_tips.py` merges them with tips; `core/extract_best_realistic_odds.py` updates tips with the best available odds for ROI.
 - **Dispatch & ROI:** `core/dispatch_tips.py` formats tips for Telegram. `roi/roi_tracker_advised.py` and `roi/send_daily_roi_summary.py` track daily performance and report ROI.
 - **Explainability:** `model_feature_importance.py` plots SHAP values and can upload the chart to S3.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ bash core/run_pipeline_with_venv.sh --dev
 
 Most Python scripts accept a `--debug` flag for verbose logging.
 
+**Important:** run inference scripts from the repository root. For example:
+
+```bash
+python core/run_inference_and_select_top1.py
+```
+Executing this command while inside the `core/` directory will raise a `ModuleNotFoundError` unless you set `PYTHONPATH=..`.
+
 This script uploads racecards, fetches odds, runs model inference, dispatches tips to Telegram, and uploads logs to S3. You can also run scripts individually for more control.
 
 ---


### PR DESCRIPTION
## Summary
- clarify in `Docs/quickstart.md` that inference scripts must be run from repo root
- add the same note in the main README and Docs/README

## Testing
- `pytest -q`
- `pre-commit run --files $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844a64d256083248f5562e2905b5209