### PR TITLE
Add roi_by_confidence_band summarise test

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Blocked or reassigned NAPs logged to `logs/nap_override_YYYY-MM-DD.log`.
 - NAP removed entirely when no tip meets the cap, with log entry noted.
 - Added unit tests for `tmcli` subcommands.
+- Added unit test for `roi_by_confidence_band.summarise`.
 - ROI trackers now support `--tag` filtering for NAP/Value tips.
 
 

--- a/tests/test_roi_by_confidence_band.py
+++ b/tests/test_roi_by_confidence_band.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from roi_by_confidence_band import summarise
+
+
+def test_summarise_basic():
+    df = pd.DataFrame(
+        {
+            "Confidence": [0.82, 0.83, 0.87, 0.93],
+            "Profit": [1, -1, 0.5, 1],
+            "Stake": [1, 1, 1, 2],
+            "Position": ["1", "2", "1", "0"],
+        }
+    )
+
+    summary = summarise(df).reset_index(drop=True)
+
+    expected = pd.DataFrame(
+        {
+            "Band": ["0.80–0.85", "0.85–0.90", "0.90+"],
+            "Tips": [2.0, 1.0, 1.0],
+            "Wins": [1.0, 1.0, 0.0],
+            "Stake": [2.0, 1.0, 2.0],
+            "Profit": [0.0, 0.5, 1.0],
+            "Win %": [50.0, 100.0, 0.0],
+            "ROI %": [0.0, 50.0, 50.0],
+        }
+    )
+
+    assert_frame_equal(summary, expected)


### PR DESCRIPTION
## Summary
- test summarise function of roi_by_confidence_band
- document new test in CHANGELOG

## Testing
- `pre-commit run --files tests/test_roi_by_confidence_band.py Docs/CHANGELOG.md`
- `pytest tests/test_roi_by_confidence_band.py`

------
https://chatgpt.com/codex/tasks/task_e_68448d48bcf0832494d37cd2b022d3d0