### PR TITLE
Fix changelog bullet formatting

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 - `roi_tracker_advised.py` and `tag_roi_tracker.py` now accept `--tag` to filter tips by tag substring.
-- Removed duplicate arguments and calculations in `tag_roi_tracker.py`. Added `--dev` option.
+- Removed duplicate arguments and calculations in `tag_roi_tracker.py`.
+- Added `--dev` option.
 
 ## 2025-06-08
 


### PR DESCRIPTION
## Summary
- tidy bullet list for 2025-06-09 entry in Docs/CHANGELOG

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684495cb4098832482cbfe74caf9e2a0