### PR TITLE
Fix inference path issue and document module usage

### DIFF
--- a/Docs/model_storage.md
+++ b/Docs/model_storage.md
@@ -18,7 +18,8 @@ Extract the archive to obtain `tipping-monster-xgb-model.bst` and
 tar -xzf tipping-monster-xgb-model-2025-06-06.tar.gz
 ```
 
-The inference script `run_inference_and_select_top1.py` will automatically
+The inference script should be run with `python -m core.run_inference_and_select_top1`
+or from a shell where the repository root is on `PYTHONPATH`. It will automatically
 download the specified model from S3 if it is not present locally.
 
 Large model files are tracked with **Git LFS**. If you clone the repository with

--- a/Docs/quickstart.md
+++ b/Docs/quickstart.md
@@ -32,7 +32,7 @@ A typical daily pipeline runs the following steps:
 05:00  core/daily_upload_racecards.sh  # Pull racecards via rpscrape
 05:06  core/daily_flatten.sh           # Flatten racecards for model input
 08:00  core/fetch_betfair_odds.py      # Capture odds snapshot
-08:05  core/run_inference_and_select_top1.py  # Predict and select tips
+08:05  python -m core.run_inference_and_select_top1  # Predict and select tips
 08:08  core/merge_odds_into_tips.py    # Attach odds to tips
 08:10  [disabled] generate_commentary_bedrock.py  # Script not included
 08:12  core/dispatch_tips.py           # Send tips to Telegram
@@ -46,7 +46,7 @@ These times are detailed in `Docs/monster_overview.md`.
 
 - **Training:** `core/train_model_v6.py` and `core/train_modelv7.py` load historical data and produce an XGBoost model.
 - **Model Comparison:** `core/compare_model_v6_v7.py` trains both versions side by side and logs confidence deltas.
-- **Inference:** `core/run_inference_and_select_top1.py` downloads the latest model, predicts on flattened racecards and uploads predictions.
+- **Inference:** run with `python -m core.run_inference_and_select_top1` (or ensure the repo root is on `PYTHONPATH`). This downloads the latest model, predicts on flattened racecards and uploads predictions.
 - **Odds Integration:** `core/fetch_betfair_odds.py` grabs odds snapshots; `core/merge_odds_into_tips.py` merges them with tips; `core/extract_best_realistic_odds.py` updates tips with the best available odds for ROI.
 - **Dispatch & ROI:** `core/dispatch_tips.py` formats tips for Telegram. `roi/roi_tracker_advised.py` and `roi/send_daily_roi_summary.py` track daily performance and report ROI.
 - **Explainability:** `model_feature_importance.py` plots SHAP values and can upload the chart to S3.
@@ -56,7 +56,7 @@ These times are detailed in `Docs/monster_overview.md`.
 
 1. **Read through `Docs/monster_overview.md`** to understand the full pipeline and feature set.
 2. **Consult `Docs/ops.md`** for cron schedules and log locations.
-3. Explore the training (`core/train_model_v6.py`) and inference (`core/run_inference_and_select_top1.py`) scripts to see how predictions are generated.
+3. Explore the training (`core/train_model_v6.py`) and inference (`python -m core.run_inference_and_select_top1`) scripts to see how predictions are generated. Running the inference script directly requires the repo root to be on `PYTHONPATH`.
 4. Review the ROI scripts (e.g., `roi/roi_tracker_advised.py`) and `roi/run_roi_pipeline.sh` to understand profit tracking.
 5. Check the TODO lists in `Docs/monster_todo.md` and `Docs/TIPPING_MONSTER_ROI_TODO.md` for future work items.
 6. Run `./dev-check.sh` followed by `make test` to verify your setup.

--- a/core/run_inference_and_select_top1.py
+++ b/core/run_inference_and_select_top1.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import json
 import os
 import pandas as pd


### PR DESCRIPTION
## Summary
- ensure `core/run_inference_and_select_top1.py` can be executed from any cwd by appending repo root to `sys.path`
- update quickstart docs with module run commands
- add note about `PYTHONPATH` to model storage docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'validate_features')*
- `python core/run_inference_and_select_top1.py` *(fails: IndexError: list index out of range)*
- `cd core && python run_inference_and_select_top1.py` *(fails: IndexError: list index out of range)*


------
https://chatgpt.com/codex/tasks/task_e_6844a9cabf8883248e1e1f0d52e6d345