### PR TITLE
Handle missing model tarball for inference

### DIFF
--- a/Docs/model_storage.md
+++ b/Docs/model_storage.md
@@ -18,8 +18,11 @@ Extract the archive to obtain `tipping-monster-xgb-model.bst` and
 tar -xzf tipping-monster-xgb-model-2025-06-06.tar.gz
 ```
 
-The inference script `run_inference_and_select_top1.py` will automatically
-download the specified model from S3 if it is not present locally.
+The inference script `run_inference_and_select_top1.py` automatically selects
+the most recent `tipping-monster-xgb-model-*.tar.gz` in the repository root. If
+no tarball is found, it exits with `FileNotFoundError: No model tarball found.
+Download one from S3 or run training.` When a path or S3 key is provided via
+`--model`, the script downloads that file if missing locally.
 
 Large model files are tracked with **Git LFS**. If you clone the repository with
 LFS enabled, running `git lfs pull` will download any referenced model pointers.

--- a/Docs/quickstart.md
+++ b/Docs/quickstart.md
@@ -46,7 +46,10 @@ These times are detailed in `Docs/monster_overview.md`.
 
 - **Training:** `core/train_model_v6.py` and `core/train_modelv7.py` load historical data and produce an XGBoost model.
 - **Model Comparison:** `core/compare_model_v6_v7.py` trains both versions side by side and logs confidence deltas.
-- **Inference:** `core/run_inference_and_select_top1.py` downloads the latest model, predicts on flattened racecards and uploads predictions.
+- **Inference:** `core/run_inference_and_select_top1.py` chooses the most recent
+  `tipping-monster-xgb-model-*.tar.gz` in the repository root and downloads it
+  from S3 if a path is provided. If no model is available, the script exits with
+  `FileNotFoundError`.
 - **Important:** run this script from the **repository root**:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -173,7 +173,10 @@ Run `compare_model_v6_v7.py` to train both model versions on the same historical
 Trained models are uploaded to S3 rather than stored in the repository. See
 [Docs/model_storage.md](Docs/model_storage.md) for details on downloading the
 latest model tarball from the `tipping-monster` bucket. The inference scripts
-will automatically fetch the specified model if it is missing locally.
+automatically choose the newest `tipping-monster-xgb-model-*.tar.gz` in the
+repository root. If no model is found, they exit with `FileNotFoundError` and
+instruct you to download one from S3 or train locally. When a path is provided
+via `--model`, that file is downloaded if missing locally.
 
 ## Model Transparency and Self‑Training
 

--- a/core/run_inference_and_select_top1.py
+++ b/core/run_inference_and_select_top1.py
@@ -19,7 +19,12 @@ from tippingmonster.env_loader import load_env
 load_env()
 
 # === ARGUMENT PARSING ===
-latest_model = sorted(glob.glob("tipping-monster-xgb-model-*.tar.gz"))[-1]
+models = sorted(glob.glob("tipping-monster-xgb-model-*.tar.gz"))
+if not models:
+    raise FileNotFoundError(
+        "No model tarball found. Download one from S3 or run training."
+    )
+latest_model = models[-1]
 parser = argparse.ArgumentParser()
 parser.add_argument("--model", default=latest_model, help="Path to model .tar.gz (S3-relative or local)")
 parser.add_argument("--input", default=None, help="Path to input JSONL")


### PR DESCRIPTION
## Summary
- exit with FileNotFoundError when no model tarball exists
- document new inference behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844b4ba37b0832491ce896180f1ec04