### PR TITLE
Fix docs after tmcli move

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -24,7 +24,7 @@
 ### Added
 - `model_drift_report.py` generates a markdown summary highlighting SHAP feature drift.
 - `roi_by_confidence_band.py` aggregates tip ROI by confidence band and writes `logs/roi/roi_by_confidence_band_*.csv`.
-- `cli/tmcli.py` now supports `dispatch-tips` and `send-roi` commands for one-line Telegram posts.
+ - `tmcli.py` now supports `dispatch-tips` and `send-roi` commands for one-line Telegram posts.
 
 ## 2025-06-07
 
@@ -44,7 +44,7 @@
 
 ## 2025-06-07 — CLI Helper
 
-- Added `cli/tmcli.py` with `pipeline`, `roi`, `sniper`, and `healthcheck` subcommands.
+ - Added `tmcli.py` with `pipeline`, `roi`, `sniper`, and `healthcheck` subcommands.
 - Each command supports a `--dev` flag for safe local testing.
 - Documented CLI usage in README and ops guide.
 

--- a/Docs/monster_todo.md
+++ b/Docs/monster_todo.md
@@ -157,7 +157,7 @@ A living roadmap of every feature, fix, and dream for the Tipping Monster system
 
 74. **Pre-commit Hooks** — black/flake8/isort run automatically.
 75. **Central `.env` Loader** — load env vars at script start.
-76. **Unified CLI** — `cli/tmcli.py` with subcommands.
+76. **Unified CLI** — `tmcli.py` with subcommands.
 77. **GitHub Actions CI** — run tests automatically.
 78. **Tip Dataclass** — typed representation for tips.
 79. **Validate Features Utility** — check dataset vs `features.json`.

--- a/Docs/ops.md
+++ b/Docs/ops.md
@@ -21,11 +21,11 @@ The system relies on a series of cron jobs to perform regular tasks. Below is a 
 ### Core Pipeline & Odds Fetching
 
 
-1.  **Run Main Pipeline (`run_pipeline_with_venv.sh` or `cli/tmcli.py pipeline`)**
+1.  **Run Main Pipeline (`run_pipeline_with_venv.sh` or `tmcli.py pipeline`)**
     *   **Frequency:** Daily at 05:00
     *   **Purpose:** Executes the main data processing and tipping pipeline. This likely involves fetching racecards, running predictions, selecting tips, and preparing them for dispatch.
     *   **Command:** `bash /home/ec2-user/tipping-monster/safecron.sh pipeline /bin/bash /home/ec2-user/tipping-monster/run_pipeline_with_venv.sh`
-    *   **Alt:** `python cli/tmcli.py pipeline --dev` for safe local testing.
+    *   **Alt:** `python tmcli.py pipeline --dev` (run from the repository root) for safe local testing.
     *   **Internal Logs:** Check `logs/inference/`, `logs/dispatch/` for detailed logs from this pipeline.
 
 2.  **Fetch Betfair Odds (Hourly)**
@@ -55,7 +55,7 @@ Scripts are now organised under `core/` and `roi/` directories. The old `ROI/` f
     *   **Frequency:** Daily at 22:50
     *   **Purpose:** Executes the ROI (Return on Investment) calculation pipeline. This likely processes sent tips and their results to generate ROI statistics.
     *   **Command:** `bash /home/ec2-user/tipping-monster/safecron.sh roi_pipeline /bin/bash /home/ec2-user/tipping-monster/run_roi_pipeline.sh`
-    *   **Alt:** `python cli/tmcli.py roi --date $(date +\%F)`
+    *   **Alt:** `python tmcli.py roi --date $(date +\%F)` (run from the repository root)
     *   **Internal Logs:** Check `logs/roi/` for detailed ROI logs.
 
 6.  **Generate Master Subscriber Log & Upload (`roi/generate_subscriber_log.py`)**
@@ -100,10 +100,10 @@ Scripts are now organised under `core/` and `roi/` directories. The old `ROI/` f
     *   **Command:** `find /home/ec2-user/tipping-monster/logs/ -type f -name "*.log" -mtime +14 -delete`
     *   **Note:** Ensure this crontab line is updated as per `Docs/instructions.md`.
 
-13. **Healthcheck Logs (`cli/tmcli.py healthcheck`)**
+13. **Healthcheck Logs (`tmcli.py healthcheck`)**
     *   **Frequency:** Daily at 00:05
     *   **Purpose:** Verifies key log files exist and writes a status line to `logs/healthcheck.log`.
-    *   **Command:** `bash /home/ec2-user/tipping-monster/safecron.sh healthcheck /home/ec2-user/tipping-monster/.venv/bin/python /home/ec2-user/tipping-monster/cli/tmcli.py healthcheck --date $(date +\%F)`
+    *   **Command:** `bash /home/ec2-user/tipping-monster/safecron.sh healthcheck /home/ec2-user/tipping-monster/.venv/bin/python /home/ec2-user/tipping-monster/tmcli.py healthcheck --date $(date +\%F)`
 
 ---
 

--- a/Docs/quickstart.md
+++ b/Docs/quickstart.md
@@ -22,7 +22,7 @@ Key folders and scripts include:
 - `logs/` – organized logs for inference, ROI and dispatch processes.
 - `predictions/` – daily output tips and summaries.
 - Core scripts such as `core/run_pipeline_with_venv.sh`, `core/fetch_betfair_odds.py`, and `core/dispatch_tips.py` drive the daily pipeline.
-- `cli/tmcli.py` – command-line helper with `pipeline`, `roi`, `sniper` and `healthcheck` commands.
+ - `tmcli.py` – command-line helper with `pipeline`, `roi`, `sniper` and `healthcheck` commands. Run all `tmcli` commands from the repository root, e.g. `python tmcli.py pipeline --dev`.
 
 Before running any scripts, set the environment variables listed in `Docs/README.md` (especially `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`). These allow the system to communicate with Telegram during live runs.
 

--- a/Docs/script_audit.txt
+++ b/Docs/script_audit.txt
@@ -71,7 +71,7 @@ utils/safecron.sh - keep
 roi/send_daily_roi_summary.py - keep
 cli/streamlit_dashboard.py - keep
 roi/tag_roi_tracker.py - keep
-cli/tmcli.py - keep
+tmcli.py - keep
 core/train_model_v6.py - keep
 core/train_modelv7.py - keep
 utils/upload_logs_to_s3.sh - keep

--- a/README.md
+++ b/README.md
@@ -84,18 +84,18 @@ This script uploads racecards, fetches odds, runs model inference, dispatches ti
 
 ## Command Line Interface (tmcli)
 
-Common workflows via CLI:
+Common workflows via CLI (run these commands from the repository root):
 
 ```bash
-python cli/tmcli.py healthcheck --date YYYY-MM-DD
-python cli/tmcli.py ensure-sent-tips YYYY-MM-DD
-python cli/tmcli.py dispatch-tips YYYY-MM-DD --telegram
-python cli/tmcli.py send-roi --date YYYY-MM-DD
-python cli/tmcli.py model-feature-importance MODEL.bst --data DATA.csv --out chart.png
-python cli/tmcli.py dispatch --date YYYY-MM-DD --telegram
-python cli/tmcli.py roi-summary --date YYYY-MM-DD --telegram
-python cli/tmcli.py chart-fi path/to/model_dir
-python cli/tmcli.py send-photo path/to/image.jpg
+python tmcli.py healthcheck --date YYYY-MM-DD
+python tmcli.py ensure-sent-tips YYYY-MM-DD
+python tmcli.py dispatch-tips YYYY-MM-DD --telegram
+python tmcli.py send-roi --date YYYY-MM-DD
+python tmcli.py model-feature-importance MODEL.bst --data DATA.csv --out chart.png
+python tmcli.py dispatch --date YYYY-MM-DD --telegram
+python tmcli.py roi-summary --date YYYY-MM-DD --telegram
+python tmcli.py chart-fi path/to/model_dir
+python tmcli.py send-photo path/to/image.jpg
 
 
 

--- a/all_scripts.txt
+++ b/all_scripts.txt
@@ -52,7 +52,7 @@ upload_logs_to_s3.sh
 weekly_roi_summary.py
 healthcheck_logs.py
 ensure_sent_tips.py
-cli/tmcli.py
+tmcli.py
 validate_tips.py
 model_drift_report.py
 evaluate_self_training.py

--- a/codex_checkpoint_2025-06-07.md
+++ b/codex_checkpoint_2025-06-07.md
@@ -3,7 +3,7 @@
 This milestone summarises all notable features and fixes committed to the repository so far.
 
 ## Added
-- **Command Line Wrapper** `cli/tmcli.py` for running the pipeline, ROI tasks and (now removed) sniper jobs with `--dev` mode support【F:cli/tmcli.py†L1-L60】.
+- **Command Line Wrapper** `tmcli.py` for running the pipeline, ROI tasks and (now removed) sniper jobs with `--dev` mode support【F:tmcli.py†L1-L60】.
 - **Dispatch All Tips** `dispatch_all_tips.py` to send full card tips in batches with Telegram integration【F:dispatch_all_tips.py†L1-L114】.
 - **Codex Action Logger** `codex_logger.py` to record agent actions to `logs/codex.log`【F:codex_logger.py†L1-L27】.
 - **Safe Cron Utility** `safecron.sh` validating `TG_BOT_TOKEN` and `TG_USER_ID` env vars before execution, alerting on failures【F:safecron.sh†L1-L40】.


### PR DESCRIPTION
## Summary
- update docs to reference `tmcli.py` at repo root
- clarify that CLI commands must be run from repository root
- clean up script audit list

## Testing
- `make test` *(fails: dev-check.sh not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b4bbabbc8324beb4e7c221de5795