### PR TITLE
Add pip cache to GH workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,6 +16,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+    - name: Cache pip
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
         pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ See the [Docs/README.md](Docs/README.md) file for complete documentation, includ
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-# GitHub Actions also installs dependencies this way
+# GitHub Actions installs dependencies this way and caches them for
+# faster test runs
 ```
 
 2. Copy `.env.example` to `.env` and fill in your credentials:


### PR DESCRIPTION
## Summary
- speed up GitHub Actions by caching pip dependencies
- document the new caching step in README

## Testing
- `pre-commit run --files .github/workflows/python-tests.yml README.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_6844bb674fa88324b6ed533706c2e477