### PR TITLE
Add validate_features wrapper

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -24,7 +24,8 @@
 ### Added
 - `model_drift_report.py` generates a markdown summary highlighting SHAP feature drift.
 - `roi_by_confidence_band.py` aggregates tip ROI by confidence band and writes `logs/roi/roi_by_confidence_band_*.csv`.
- - `tmcli.py` now supports `dispatch-tips` and `send-roi` commands for one-line Telegram posts.
+- `tmcli.py` now supports `dispatch-tips` and `send-roi` commands for one-line Telegram posts.
+- `validate_features.py` wraps `core.validate_features` for backward compatibility.
 
 ## 2025-06-07
 

--- a/all_scripts.txt
+++ b/all_scripts.txt
@@ -54,6 +54,7 @@ healthcheck_logs.py
 ensure_sent_tips.py
 tmcli.py
 validate_tips.py
+validate_features.py
 model_drift_report.py
 evaluate_self_training.py
 

--- a/core/validate_features.py
+++ b/core/validate_features.py
@@ -1,8 +1,8 @@
 import argparse
 import json
 from typing import List, Tuple
+
 import pandas as pd
-import sys
 
 
 def load_dataset(path: str) -> pd.DataFrame:
@@ -15,7 +15,9 @@ def load_dataset(path: str) -> pd.DataFrame:
         raise ValueError(f"Unsupported file type: {path}")
 
 
-def validate_dataset_features(features: List[str], df: pd.DataFrame) -> Tuple[List[str], List[str]]:
+def validate_dataset_features(
+    features: List[str], df: pd.DataFrame
+) -> Tuple[List[str], List[str]]:
     """Return missing and extra feature columns compared to the DataFrame."""
     feature_set = set(features)
     data_set = set(df.columns)
@@ -25,9 +27,13 @@ def validate_dataset_features(features: List[str], df: pd.DataFrame) -> Tuple[Li
 
 
 def main(argv: List[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Validate dataset columns against features.json")
+    parser = argparse.ArgumentParser(
+        description="Validate dataset columns against features.json"
+    )
     parser.add_argument("dataset", help="CSV or JSONL dataset file")
-    parser.add_argument("--features", default="features.json", help="Path to features.json")
+    parser.add_argument(
+        "--features", default="features.json", help="Path to features.json"
+    )
     args = parser.parse_args(argv)
 
     with open(args.features) as f:

--- a/validate_features.py
+++ b/validate_features.py
@@ -1,0 +1,1 @@
+from core.validate_features import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- expose `validate_features` at repo root for backward compatibility
- document new helper in the changelog
- list the script in `all_scripts.txt`
- remove an unused import in `core.validate_features`

## Testing
- `pre-commit run --files validate_features.py core/validate_features.py`
- `pre-commit run --files Docs/CHANGELOG.md all_scripts.txt`
- `TM_DEV=1 pytest -k validate_features` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6844ba22b5f8832482d707abd29345f7