### PR TITLE
Add tag helper and re-export

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -8,6 +8,11 @@
 ### Fixed
 - Added missing `requests` import in `scripts/morning_digest.py` so Telegram posts work.
 
+## 2025-06-11
+
+### Added
+- New `tip_has_tag()` helper in `tippingmonster.utils` for tag substring checks.
+
 ## 2025-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Use `--telegram` to actually post messages and `--explain` to append a short "Wh
 The `tippingmonster` package also exposes handy helpers like
 `send_telegram_message()` and the new `send_telegram_photo()` for posting
 images with captions.
+It also includes `tip_has_tag()` for quickly checking if a tip has a
+particular tag substring.
 
 ## Health Check
 

--- a/tippingmonster/__init__.py
+++ b/tippingmonster/__init__.py
@@ -14,6 +14,7 @@ from .utils import (
     repo_root,
     send_telegram_message,
     send_telegram_photo,
+    tip_has_tag,
 )
 from .helpers import dispatch, send_daily_roi, generate_chart
 
@@ -31,5 +32,6 @@ __all__ = [
     "dispatch",
     "send_daily_roi",
     "generate_chart",
+    "tip_has_tag",
     "load_env",
 ]

--- a/tippingmonster/utils.py
+++ b/tippingmonster/utils.py
@@ -161,3 +161,7 @@ def calculate_profit(row) -> float:
         return round(win_profit, 2)
 
 
+def tip_has_tag(tip: dict, tag: str) -> bool:
+    """Return True if the tip's tags include ``tag`` (case-insensitive substring)."""
+    tag_lower = tag.lower()
+    return any(tag_lower in str(t).lower() for t in tip.get("tags", []))


### PR DESCRIPTION
## Summary
- add `tip_has_tag` helper in `tippingmonster.utils`
- export the helper from the package
- mention the function in README
- document change in `CHANGELOG`

## Testing
- `pre-commit run --files tippingmonster/utils.py tippingmonster/__init__.py README.md Docs/CHANGELOG.md`
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6844bdf488748324b88d509b69632fdf