### PR TITLE
Fix missing tip_has_tag implementation

### DIFF
--- a/tests/test_tmcli.py
+++ b/tests/test_tmcli.py
@@ -1,8 +1,8 @@
 import json
 import os
+import subprocess
 import sys
 from datetime import date
-import subprocess
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -13,8 +13,8 @@ from cli import tmcli
 def test_tmcli_healthcheck(tmp_path):
     date_str = "2025-06-06"
     logs = tmp_path / "logs"
-    (logs / "dispatch").mkdir(parents=True)
-    (logs / "inference").mkdir(parents=True)
+    (logs / "dispatch").mkdir(parents=True, exist_ok=True)
+    (logs / "inference").mkdir(parents=True, exist_ok=True)
     (logs / "dispatch" / f"sent_tips_{date_str}.jsonl").write_text("ok")
     (logs / "inference" / f"pipeline_{date_str}.log").write_text("ok")
     (logs / "inference" / f"odds_0800_{date_str}.log").write_text("ok")
@@ -33,8 +33,8 @@ def test_tmcli_healthcheck_missing_files(tmp_path):
     logs.mkdir(parents=True)
     (logs / f"sent_tips_{date_str}.jsonl").write_text("ok")
     logs = tmp_path / "logs"
-    (logs / "dispatch").mkdir(parents=True)
-    (logs / "inference").mkdir(parents=True)
+    (logs / "dispatch").mkdir(parents=True, exist_ok=True)
+    (logs / "inference").mkdir(parents=True, exist_ok=True)
     (logs / "dispatch" / f"sent_tips_{date_str}.jsonl").write_text("ok")
     os.chdir(tmp_path)
     tmcli.main(["healthcheck", "--date", date_str, "--out-log", "hc.log"])
@@ -64,7 +64,9 @@ def test_tmcli_ensure_sent_tips(tmp_path):
     assert sent.read_text() == "tip"
 
 
-def test_tmcli_dispatch_tips(monkeypatch):
+def test_tmcli_dispatch_tips(monkeypatch, tmp_path):
+    date_str = "2025-06-06"
+
     calls = {}
     monkeypatch.delenv("TM_DEV_MODE", raising=False)
     monkeypatch.delenv("TM_LOG_DIR", raising=False)
@@ -87,7 +89,6 @@ def test_tmcli_dispatch_tips(monkeypatch):
         calls["cmd"] = cmd
         calls["check"] = check
 
-
     monkeypatch.setattr(subprocess, "run", fake_run)
     tmcli.main(["dispatch-tips", "2025-06-06", "--telegram", "--dev"])
     assert "dispatch_tips.py" in calls["cmd"][1]
@@ -99,7 +100,7 @@ def test_tmcli_dispatch_tips(monkeypatch):
     monkeypatch.delenv("TM_LOG_DIR", raising=False)
 
 
-def test_tmcli_send_roi(monkeypatch):
+def test_tmcli_send_roi(monkeypatch, tmp_path):
     calls = {}
     monkeypatch.delenv("TM_DEV_MODE", raising=False)
     monkeypatch.delenv("TM_LOG_DIR", raising=False)
@@ -118,6 +119,24 @@ def test_tmcli_send_roi(monkeypatch):
     monkeypatch.delenv("TM_DEV_MODE", raising=False)
     monkeypatch.delenv("TM_LOG_DIR", raising=False)
 
+    model_path = Path(__file__).resolve().parents[1] / "tipping-monster-xgb-model.bst"
+    data_path = tmp_path / "data.jsonl"
+    with open(data_path, "w") as f:
+        json.dump(
+            {
+                "draw": 0,
+                "or": 0,
+                "rpr": 0,
+                "lbs": 0,
+                "age": 0,
+                "dist_f": 0,
+                "class": 0,
+                "going": "G",
+                "prize": 0,
+            },
+            f,
+        )
+        f.write("\n")
 
     os.chdir(tmp_path)
     tmcli.main(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
-import sys
 import os
+import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -12,10 +12,6 @@ from tippingmonster import (
     repo_root,
     send_telegram_message,
     send_telegram_photo,
-    calculate_profit,
-    repo_root,
-    repo_path,
-    logs_path,
     tip_has_tag,
 )
 
@@ -49,6 +45,8 @@ def test_send_telegram_message(monkeypatch):
 
 def test_send_telegram_photo(monkeypatch, tmp_path):
     calls = {}
+    monkeypatch.delenv("TM_DEV_MODE", raising=False)
+    monkeypatch.delenv("TM_LOG_DIR", raising=False)
 
     def fake_post(url, data=None, files=None, timeout=None):
         calls["url"] = url
@@ -156,12 +154,12 @@ def test_repo_and_logs_path_helpers():
 
 
 def test_logs_path_dev(monkeypatch):
-    monkeypatch.setenv('TM_DEV_MODE', '1')
-    p = logs_path('dispatch')
-    assert str(p).endswith('logs/dev/dispatch')
+    monkeypatch.setenv("TM_DEV_MODE", "1")
+    p = logs_path("dispatch")
+    assert str(p).endswith("logs/dev/dispatch")
 
 
 def test_tip_has_tag_basic():
-    tip = {'tags': ['🧠 Monster NAP', '⚡ Fresh']}
-    assert tip_has_tag(tip, 'NAP')
-    assert not tip_has_tag(tip, 'Value')
+    tip = {"tags": ["🧠 Monster NAP", "⚡ Fresh"]}
+    assert tip_has_tag(tip, "NAP")
+    assert not tip_has_tag(tip, "Value")

--- a/tipping-monster-xgb-model.bst
+++ b/tipping-monster-xgb-model.bst
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f05fd31b23e56d110a8d71f175030a9ec480340d121f9c37acb7226d564478b
+size 1399

--- a/tippingmonster/__init__.py
+++ b/tippingmonster/__init__.py
@@ -14,6 +14,7 @@ from .utils import (
     repo_root,
     send_telegram_message,
     send_telegram_photo,
+    tip_has_tag,
 )
 from .helpers import dispatch, send_daily_roi, generate_chart
 
@@ -28,6 +29,7 @@ __all__ = [
     "send_telegram_message",
     "send_telegram_photo",
     "calculate_profit",
+    "tip_has_tag",
     "dispatch",
     "send_daily_roi",
     "generate_chart",

--- a/tippingmonster/utils.py
+++ b/tippingmonster/utils.py
@@ -161,3 +161,15 @@ def calculate_profit(row) -> float:
         return round(win_profit, 2)
 
 
+def tip_has_tag(tip: dict, tag: str) -> bool:
+    """Return ``True`` if ``tag`` appears in ``tip``'s tags list."""
+
+    tags = tip.get("tags", [])
+    tag_lower = tag.lower()
+    for t in tags:
+        try:
+            if tag_lower in str(t).lower():
+                return True
+        except Exception:
+            continue
+    return False


### PR DESCRIPTION
## Summary
- implement `tip_has_tag` utility
- expose new helper via `tippingmonster` package
- add lightweight model artifact for tests
- patch CLI tests to run correctly
- ensure Telegram photo test clears dev env

## Testing
- `pre-commit run --files tippingmonster/utils.py tippingmonster/__init__.py tests/test_tmcli.py tests/test_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844bde76d9483249de8a7bf6180af55