### PR TITLE
Fix CLI imports and support module execution

### DIFF
--- a/Docs/ops.md
+++ b/Docs/ops.md
@@ -25,7 +25,7 @@ The system relies on a series of cron jobs to perform regular tasks. Below is a 
     *   **Frequency:** Daily at 05:00
     *   **Purpose:** Executes the main data processing and tipping pipeline. This likely involves fetching racecards, running predictions, selecting tips, and preparing them for dispatch.
     *   **Command:** `bash /home/ec2-user/tipping-monster/safecron.sh pipeline /bin/bash /home/ec2-user/tipping-monster/run_pipeline_with_venv.sh`
-    *   **Alt:** `python cli/tmcli.py pipeline --dev` for safe local testing.
+    *   **Alt:** `python cli/tmcli.py pipeline --dev` or `python -m cli.tmcli pipeline --dev` for safe local testing.
     *   **Internal Logs:** Check `logs/inference/`, `logs/dispatch/` for detailed logs from this pipeline.
 
 2.  **Fetch Betfair Odds (Hourly)**
@@ -55,7 +55,7 @@ Scripts are now organised under `core/` and `roi/` directories. The old `ROI/` f
     *   **Frequency:** Daily at 22:50
     *   **Purpose:** Executes the ROI (Return on Investment) calculation pipeline. This likely processes sent tips and their results to generate ROI statistics.
     *   **Command:** `bash /home/ec2-user/tipping-monster/safecron.sh roi_pipeline /bin/bash /home/ec2-user/tipping-monster/run_roi_pipeline.sh`
-    *   **Alt:** `python cli/tmcli.py roi --date $(date +\%F)`
+    *   **Alt:** `python cli/tmcli.py roi --date $(date +\%F)` or `python -m cli.tmcli roi --date $(date +\%F)`
     *   **Internal Logs:** Check `logs/roi/` for detailed ROI logs.
 
 6.  **Generate Master Subscriber Log & Upload (`roi/generate_subscriber_log.py`)**
@@ -104,6 +104,7 @@ Scripts are now organised under `core/` and `roi/` directories. The old `ROI/` f
     *   **Frequency:** Daily at 00:05
     *   **Purpose:** Verifies key log files exist and writes a status line to `logs/healthcheck.log`.
     *   **Command:** `bash /home/ec2-user/tipping-monster/safecron.sh healthcheck /home/ec2-user/tipping-monster/.venv/bin/python /home/ec2-user/tipping-monster/cli/tmcli.py healthcheck --date $(date +\%F)`
+    *   **Alt:** `python -m cli.tmcli healthcheck --date $(date +\%F)`
 
 ---
 

--- a/Docs/quickstart.md
+++ b/Docs/quickstart.md
@@ -22,7 +22,7 @@ Key folders and scripts include:
 - `logs/` – organized logs for inference, ROI and dispatch processes.
 - `predictions/` – daily output tips and summaries.
 - Core scripts such as `core/run_pipeline_with_venv.sh`, `core/fetch_betfair_odds.py`, and `core/dispatch_tips.py` drive the daily pipeline.
-- `cli/tmcli.py` – command-line helper with `pipeline`, `roi`, `sniper` and `healthcheck` commands.
+- `cli/tmcli.py` – command-line helper with `pipeline`, `roi`, `sniper` and `healthcheck` commands. Use it directly or run `python -m cli.tmcli`.
 
 Before running any scripts, set the environment variables listed in `Docs/README.md` (especially `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`). These allow the system to communicate with Telegram during live runs.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ python cli/tmcli.py dispatch --date YYYY-MM-DD --telegram
 python cli/tmcli.py roi-summary --date YYYY-MM-DD --telegram
 python cli/tmcli.py chart-fi path/to/model_dir
 python cli/tmcli.py send-photo path/to/image.jpg
+python -m cli.tmcli dispatch-tips --date YYYY-MM-DD --telegram
 
 
 

--- a/cli/tmcli.py
+++ b/cli/tmcli.py
@@ -1,6 +1,9 @@
 import argparse
 from datetime import date
 from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from core.dispatch_tips import main as dispatch_main
 from model_feature_importance import generate_chart

--- a/core/compare_model_v6_v7.py
+++ b/core/compare_model_v6_v7.py
@@ -8,6 +8,11 @@ set and records the confidence scores for each horse in
 
 Columns: ``Race``, ``Horse``, ``v6_conf``, ``v7_conf``, ``delta``, ``winner``.
 """
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import glob
 import os
 import pandas as pd

--- a/core/run_inference_and_select_top1.py
+++ b/core/run_inference_and_select_top1.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import json
 import os
 import pandas as pd

--- a/core/train_modelv7.py
+++ b/core/train_modelv7.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import os
 import tarfile
 import shutil

--- a/model_feature_importance.py
+++ b/model_feature_importance.py
@@ -103,6 +103,10 @@ def generate_shap_chart(
     return out
 
 
+# Backwards compatibility for older CLI imports
+generate_chart = generate_shap_chart
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Generate SHAP feature importance chart")
     parser.add_argument("dataset", nargs="?", default=None,

--- a/tippingmonster/__init__.py
+++ b/tippingmonster/__init__.py
@@ -14,6 +14,7 @@ from .utils import (
     repo_root,
     send_telegram_message,
     send_telegram_photo,
+    tip_has_tag,
 )
 from .helpers import dispatch, send_daily_roi, generate_chart
 
@@ -28,6 +29,7 @@ __all__ = [
     "send_telegram_message",
     "send_telegram_photo",
     "calculate_profit",
+    "tip_has_tag",
     "dispatch",
     "send_daily_roi",
     "generate_chart",

--- a/tippingmonster/utils.py
+++ b/tippingmonster/utils.py
@@ -161,3 +161,10 @@ def calculate_profit(row) -> float:
         return round(win_profit, 2)
 
 
+def tip_has_tag(tip: dict, tag: str) -> bool:
+    """Return True if ``tag`` is found in ``tip['tags']`` (case-insensitive)."""
+    tags = tip.get("tags") or []
+    tag = tag.lower()
+    return any(tag in str(t).lower() for t in tags)
+
+

--- a/validate_features.py
+++ b/validate_features.py
@@ -1,0 +1,1 @@
+from core.validate_features import *


### PR DESCRIPTION
## Summary
- add sys.path adjustments for various scripts
- add alias for `generate_chart`
- add validate_features shim
- document module usage for `tmcli`
- restore `tip_has_tag` export

## Testing
- `python core/run_inference_and_select_top1.py --help` *(fails: IndexError)*
- `python core/train_modelv7.py --help` *(fails: IndexError)*
- `python compare_model_v6_v7.py --help` *(fails: Unable to locate credentials)*
- `python cli/tmcli.py --help`
- `pytest -q` *(fails: 5 failed, 50 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6844b4b18a44832491b60a49dd07c98f