### PR TITLE
Fix dispatch imports for local runs

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2025-07-09
+
+### Changed
+- Dispatch and ROI scripts now append the repository root to `sys.path` so they can be run directly without setting `PYTHONPATH`.
+- Documentation updated to mention using `PYTHONPATH` or `python -m` when executing scripts by path.
+
 ## 2025-07-07
 
 ### Fixed

--- a/Docs/ec2_setup_guide.md
+++ b/Docs/ec2_setup_guide.md
@@ -86,10 +86,12 @@ This guide explains how to deploy Tipping Monster on a fresh Ubuntu EC2 instance
    - `utils/upload_logs_to_s3.sh` – uploads logs to S3.
 4. **Testing commands before enabling cron:**
    ```bash
-   python core/run_inference_and_select_top1.py --dev
-   python core/dispatch_tips.py $(date +%F) --telegram --dev
-   python cli/tmcli.py healthcheck --date $(date +%F)
-   ```
+    python core/run_inference_and_select_top1.py --dev
+    python core/dispatch_tips.py $(date +%F) --telegram --dev
+    python cli/tmcli.py healthcheck --date $(date +%F)
+    ```
+    Running these scripts from inside the `core/` or `roi/` folders requires the
+    repository root to be on `PYTHONPATH` or using `python -m`.
 5. Once everything works in dev mode, remove the `--dev` flags and update your crontab accordingly.
 
 

--- a/Docs/quickstart.md
+++ b/Docs/quickstart.md
@@ -58,7 +58,7 @@ These times are detailed in `Docs/monster_overview.md`.
 ```bash
 python core/run_inference_and_select_top1.py
 ```
-Running it while inside `core/` triggers a `ModuleNotFoundError` unless you set `PYTHONPATH=..`.
+Running it while inside `core/` triggers a `ModuleNotFoundError` unless the repository root is on your `PYTHONPATH` or you run `python -m core.run_inference_and_select_top1`.
 - **Odds Integration:** `core/fetch_betfair_odds.py` grabs odds snapshots; `core/merge_odds_into_tips.py` merges them with tips; `core/extract_best_realistic_odds.py` updates tips with the best available odds for ROI.
 - **Dispatch & ROI:** `core/dispatch_tips.py` formats tips for Telegram. `roi/roi_tracker_advised.py` and `roi/send_daily_roi_summary.py` track daily performance and report ROI.
 - **Explainability:** `model_feature_importance.py` plots SHAP values and can upload the chart to S3.
@@ -68,7 +68,7 @@ Running it while inside `core/` triggers a `ModuleNotFoundError` unless you set 
 
 1. **Read through `Docs/monster_overview.md`** to understand the full pipeline and feature set.
 2. **Consult `Docs/ops.md`** for cron schedules and log locations.
-3. Explore the training (`core/train_model_v6.py`) and inference (`python -m core.run_inference_and_select_top1`) scripts to see how predictions are generated. Running the inference script directly requires the repo root to be on `PYTHONPATH`.
+3. Explore the training (`core/train_model_v6.py`) and inference (`python -m core.run_inference_and_select_top1`) scripts to see how predictions are generated. If you run the inference script by path, ensure the repo root is on `PYTHONPATH` or use the module form above.
 4. Review the ROI scripts (e.g., `roi/roi_tracker_advised.py`) and `roi/run_roi_pipeline.sh` to understand profit tracking.
 5. Check the TODO lists in `Docs/monster_todo.md` and `Docs/TIPPING_MONSTER_ROI_TODO.md` for future work items.
 6. Run `./utils/dev-check.sh` followed by `make test` to verify your setup.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Most Python scripts accept a `--debug` flag for verbose logging.
 python core/run_inference_and_select_top1.py --dev
 ```
 Use `--dev` to disable the final S3 upload.
-Executing this command while inside the `core/` directory will raise a `ModuleNotFoundError` unless you set `PYTHONPATH=..`.
+Executing this command inside the `core/` directory fails unless the repository root is on `PYTHONPATH` or you run it as a module:
+`python -m core.run_inference_and_select_top1`.
 
 This script uploads racecards, fetches odds, runs model inference, dispatches tips to Telegram, and uploads logs to S3. You can also run scripts individually for more control.
 
@@ -113,6 +114,8 @@ python telegram_bot.py --dev  # start Telegram bot with /roi, /nap and /tip comm
 
 Run `core/dispatch_tips.py` to send the day's tips to Telegram. Use `--telegram` to
 actually post messages and `--explain` to append a short "Why we tipped this" summary generated from SHAP values.
+If you run this file from inside `core/`, set `PYTHONPATH=..` or call it as
+`python -m core.dispatch_tips` so it can locate the `core` package.
 
 Tips under **0.80** confidence are automatically skipped unless their confidence
 band showed a positive ROI in the last 30 days (tracked in

--- a/codex_log.md
+++ b/codex_log.md
@@ -418,3 +418,8 @@ error. Added tests for failing responses and documented in changelog.
 **Prompt:** Provide simple dev-to-prod instructions and script explanations
 **Files Changed:** Docs/prod_setup_cheatsheet.md, Docs/README.md, Docs/CHANGELOG.md
 **Outcome:** Added new cheatsheet doc and referenced it in main docs.
+
+## [2025-07-09] Inject repo root path for dispatch scripts
+**Prompt:** In `core/dispatch_tips.py`, inject repo-root path and update docs.
+**Files Changed:** core/dispatch_tips.py, core/dispatch_all_tips.py, roi/generate_tweet.py, roi/roi_tracker_advised.py, roi/calibrate_confidence_daily.py, roi/generate_subscriber_log.py, roi/tag_roi_tracker.py, README.md, Docs/ec2_setup_guide.md, Docs/quickstart.md, Docs/CHANGELOG.md
+**Outcome:** Scripts now run from within subfolders without `PYTHONPATH`; docs mention using `PYTHONPATH` or `python -m` when running by path.

--- a/core/dispatch_all_tips.py
+++ b/core/dispatch_all_tips.py
@@ -1,11 +1,14 @@
 import argparse
 import json
 import os
+import sys
 from collections import defaultdict
 from datetime import date
 
 from dotenv import load_dotenv
+from pathlib import Path
 
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from core.tip import Tip
 from tippingmonster import send_telegram_message
 

--- a/core/dispatch_tips.py
+++ b/core/dispatch_tips.py
@@ -4,12 +4,15 @@ import json
 import os
 import sys
 from datetime import date, timedelta
+from pathlib import Path
 from time import sleep
 
 import pandas as pd
 from dotenv import load_dotenv
 
 load_dotenv()
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from core.tip import Tip
 from tippingmonster import logs_path, send_telegram_message

--- a/roi/calibrate_confidence_daily.py
+++ b/roi/calibrate_confidence_daily.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from core.tip import Tip
 
 # === ARGUMENTS ===

--- a/roi/generate_subscriber_log.py
+++ b/roi/generate_subscriber_log.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import sys
 from pathlib import Path
 
 import pandas as pd
 
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from core.tip import Tip
 
 # === CONFIG ===

--- a/roi/generate_tweet.py
+++ b/roi/generate_tweet.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 import json
 import os
+import sys
 from datetime import date, timedelta
+from pathlib import Path
 
 import pandas as pd
 
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from core.tip import Tip
 from tippingmonster import repo_path
 

--- a/roi/roi_tracker_advised.py
+++ b/roi/roi_tracker_advised.py
@@ -2,11 +2,14 @@
 import argparse
 import json
 import os
+import sys
 import re
 from datetime import datetime
+from pathlib import Path
 
 import pandas as pd
 
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from core.tip import Tip
 
 # isort: off

--- a/roi/tag_roi_tracker.py
+++ b/roi/tag_roi_tracker.py
@@ -2,10 +2,13 @@
 import argparse
 import json
 import os
+import sys
 import re
 
 import pandas as pd
 
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from core.tip import Tip
 from tippingmonster import get_place_terms, send_telegram_message, tip_has_tag
 


### PR DESCRIPTION
## Summary
- ensure dispatch scripts add repo root to sys.path
- document PYTHONPATH requirements in README and docs
- log update

## Testing
- `pre-commit run --files core/dispatch_tips.py Docs/* README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849e4ba3c6c8324b843c829bbf7326a