### PR TITLE
Add course filter for dispatch tips

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2025-07-10
+
+### Added
+- `dispatch_tips.py` accepts `--course` to filter tips by racecourse.
+
 ## 2025-07-09
 
 ### Changed

--- a/Docs/monster_overview.md
+++ b/Docs/monster_overview.md
@@ -22,6 +22,7 @@ These core functionalities are currently **deployed and operating seamlessly** w
 * ✅ Confidence calibration logger & detailed confidence band ROI logging
 * ✅ Weekly and daily ROI summaries
 * ✅ Sent vs unsent tip separation
+* ✅ Optional course filter for dispatch (`--course`)
 * ✅ Full logging + S3 backup
 * ✅ Pre-commit hooks enforce `black`, `isort`, and `flake8`
 * ✅ Organized log folders (`roi/`, `dispatch/`, `inference/`)

--- a/Docs/monster_todo.md
+++ b/Docs/monster_todo.md
@@ -186,6 +186,8 @@ A living roadmap of every feature, fix, and dream for the Tipping Monster system
 
 99. ✅ Flake8 cleanup across core and tests [Done: 2025-07-09]
 
+100. ✅ `--course` option to dispatch tips for a single track [Done: 2025-07-10]
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ actually post messages and `--explain` to append a short "Why we tipped this" su
 If you run this file from inside `core/`, set `PYTHONPATH=..` or call it as
 `python -m core.dispatch_tips` so it can locate the `core` package.
 
+Use `--course "Royal Ascot"` (or any track name) to dispatch tips for a single
+meeting only.
+
 Tips under **0.80** confidence are automatically skipped unless their confidence
 band showed a positive ROI in the last 30 days (tracked in
 `monster_confidence_per_day_with_roi.csv`).

--- a/cli/tmcli.py
+++ b/cli/tmcli.py
@@ -40,6 +40,7 @@ def dispatch(
     telegram: bool = False,
     dev: bool = False,
     comment_style: str | None = None,
+    course: str | None = None,
 ) -> None:
     cmd = [sys.executable, str(repo_path("core", "dispatch_tips.py")), "--date", date]
     if telegram:
@@ -50,6 +51,8 @@ def dispatch(
         os.environ["TM_LOG_DIR"] = "logs/dev"
     if comment_style:
         cmd += ["--comment-style", comment_style]
+    if course:
+        cmd += ["--course", course]
     subprocess.run(cmd, check=True)
 
 
@@ -139,6 +142,7 @@ def main(argv=None) -> None:
     )
     parser_dispatch.add_argument("--telegram", action="store_true")
     parser_dispatch.add_argument("--dev", action="store_true")
+    parser_dispatch.add_argument("--course", help="Filter tips for a racecourse")
     parser_dispatch.add_argument(
         "--comment-style",
         choices=["basic", "expressive"],
@@ -195,6 +199,7 @@ def main(argv=None) -> None:
             telegram=args.telegram,
             dev=args.dev,
             comment_style=args.comment_style,
+            course=args.course,
         )
 
     elif args.command == "validate-tips":

--- a/codex_log.md
+++ b/codex_log.md
@@ -435,3 +435,8 @@ error. Added tests for failing responses and documented in changelog.
 **Files Changed:** core/compare_model_v6_v7.py, core/fetch_betfair_odds.py, explain_model_decision.py, telegram_bot.py, tip_control_panel.py, tests/test_codex_logger.py, tests/test_dispatch_tips.py, tests/test_model_drift_report.py, tests/test_self_training_loop.py, tests/test_telegram_bot.py, Docs/CHANGELOG.md, Docs/monster_overview.md, Docs/monster_todo.md, codex_log.md
 **Outcome:** Removed unused imports and spacing issues; updated docs and task log
 
+## [2025-07-10] Course filter for dispatch
+**Prompt:** I need a dispatch tips but to be able to filter for all races at a track for example royal ascot
+**Files Changed:** core/dispatch_tips.py, tippingmonster/helpers.py, cli/tmcli.py, tests/test_tmcli.py, tests/test_dispatch_tips.py, README.md, Docs/monster_overview.md, Docs/CHANGELOG.md, Docs/monster_todo.md, codex_log.md
+**Outcome:** Added `--course` argument to filter tips by racecourse. Updated docs and tests.
+

--- a/tests/test_dispatch_tips.py
+++ b/tests/test_dispatch_tips.py
@@ -12,6 +12,7 @@ from core.dispatch_tips import (
     load_recent_roi_stats,
     select_nap_tip,
     should_skip_by_roi,
+    filter_tips_by_course,
 )
 
 # isort: on
@@ -165,3 +166,13 @@ def test_build_confidence_line_basic():
     line = build_confidence_line(tip)
     assert line.startswith("\ud83e\udde0 Model Confidence: High (92%)")
     assert "class drop" in line and "fresh" in line
+
+
+def test_filter_tips_by_course():
+    tips = [
+        {"race": "1:00 Ascot", "name": "A"},
+        {"race": "2:00 Ascot", "name": "B"},
+        {"race": "3:00 York", "name": "C"},
+    ]
+    out = filter_tips_by_course(tips, "Ascot")
+    assert len(out) == 2

--- a/tests/test_tmcli.py
+++ b/tests/test_tmcli.py
@@ -35,7 +35,12 @@ def run_command(cmd: list[str], dev: bool) -> None:
     subprocess.run(cmd, check=True, env=env)
 
 
-def dispatch(date: str, telegram: bool = False, dev: bool = False) -> None:
+def dispatch(
+    date: str,
+    telegram: bool = False,
+    dev: bool = False,
+    course: str | None = None,
+) -> None:
     cmd = [sys.executable, str(repo_path("core", "dispatch_tips.py")), "--date", date]
     if telegram:
         cmd.append("--telegram")
@@ -43,6 +48,8 @@ def dispatch(date: str, telegram: bool = False, dev: bool = False) -> None:
         cmd.append("--dev")
         os.environ["TM_DEV_MODE"] = "1"
         os.environ["TM_LOG_DIR"] = "logs/dev"
+    if course:
+        cmd += ["--course", course]
     subprocess.run(cmd, check=True)
 
 
@@ -132,6 +139,7 @@ def main(argv=None) -> None:
     )
     parser_dispatch.add_argument("--telegram", action="store_true")
     parser_dispatch.add_argument("--dev", action="store_true")
+    parser_dispatch.add_argument("--course", help="Filter tips for a racecourse")
 
     # send-roi subcommand
     parser_roi = subparsers.add_parser(
@@ -182,6 +190,7 @@ def main(argv=None) -> None:
             date=date_arg or date.today().isoformat(),
             telegram=args.telegram,
             dev=args.dev,
+            course=args.course,
         )
 
     elif args.command == "validate-tips":

--- a/tippingmonster/helpers.py
+++ b/tippingmonster/helpers.py
@@ -21,7 +21,12 @@ def _apply_dev_env(dev: bool) -> None:
         os.environ["TM_LOG_DIR"] = "logs/dev"
 
 
-def dispatch(date: str, telegram: bool = False, dev: bool = False) -> None:
+def dispatch(
+    date: str,
+    telegram: bool = False,
+    dev: bool = False,
+    course: str | None = None,
+) -> None:
     """Run ``dispatch_tips.py`` for ``date``."""
     _apply_dev_env(dev)
     cmd = [sys.executable, str(repo_path("core", "dispatch_tips.py")), "--date", date]
@@ -29,6 +34,8 @@ def dispatch(date: str, telegram: bool = False, dev: bool = False) -> None:
         cmd.append("--telegram")
     if dev:
         cmd.append("--dev")
+    if course:
+        cmd += ["--course", course]
     subprocess.run(cmd, check=True)
 
 


### PR DESCRIPTION
## Summary
- allow dispatch_tips.py to filter tips by racecourse via `--course`
- expose course parameter in helper and CLI
- update README and docs
- record change in CHANGELOG and monster_todo
- update tests for new option

## Testing
- `pre-commit run --files core/dispatch_tips.py tests/test_dispatch_tips.py tests/test_tmcli.py cli/tmcli.py tippingmonster/helpers.py Docs/CHANGELOG.md Docs/monster_overview.md Docs/monster_todo.md README.md codex_log.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ed686a208324be3f03c93d75281a