### PR TITLE
Add tip sanity checker

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - `dispatch_tips.py` accepts `--course` to filter tips by racecourse.
+- `check_tip_sanity.py` validates the latest sent tips for low confidence or missing fields.
 
 ## 2025-07-09
 

--- a/Docs/monster_overview.md
+++ b/Docs/monster_overview.md
@@ -102,6 +102,7 @@ Scripts are grouped under `core/` and `roi/` directories for clarity.
 * `track_lay_candidates_roi.py`: Computes ROI for Danger Fav lay candidates.
 * `core/trainer_stable_profile.py`: Computes 30-day win rate and ROI per trainer.
 * `trainer_intent_profiler.py`: Adds stable-form tags to tips based on recent performance.
+* `check_tip_sanity.py`: Warns if the latest sent tips have low confidence or missing odds/stake.
 
 ---
 

--- a/Docs/monster_todo.md
+++ b/Docs/monster_todo.md
@@ -190,6 +190,8 @@ A living roadmap of every feature, fix, and dream for the Tipping Monster system
 
 100. ✅ `--course` option to dispatch tips for a single track [Done: 2025-07-10]
 
+102. ✅ `check_tip_sanity.py` warns about low confidence or missing odds/stake [Done: 2025-07-10]
+
 
 
 

--- a/check_tip_sanity.py
+++ b/check_tip_sanity.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Iterable, List
+
+DATE_RE = re.compile(r"sent_tips_(\d{4}-\d{2}-\d{2})\.jsonl$")
+
+
+def find_latest_sent_file(logs_dir: Path = Path("logs")) -> Path:
+    files = []
+    for f in logs_dir.glob("sent_tips_*.jsonl"):
+        m = DATE_RE.match(f.name)
+        if m:
+            files.append((m.group(1), f))
+    if not files:
+        raise FileNotFoundError("No sent_tips_YYYY-MM-DD.jsonl found in logs/")
+    files.sort()
+    return files[-1][1]
+
+
+def load_tips(path: Path) -> List[dict]:
+    tips: List[dict] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                tips.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return tips
+
+
+def check_tip_sanity(tips: Iterable[dict]) -> List[str]:
+    warnings: List[str] = []
+    nap: tuple[str, float] | None = None
+    for tip in tips:
+        race = tip.get("race", "?")
+        name = tip.get("name", "?")
+        try:
+            conf = float(tip.get("confidence", 0))
+        except Exception:
+            conf = 0.0
+        if conf < 0.5:
+            warnings.append(
+                f"\u26a0\ufe0f Low confidence {conf:.2f} at {race} ({name})"
+            )
+        if tip.get("bf_sp") is None and tip.get("odds") is None:
+            warnings.append(f"\ud83d\udea8 Tip at {race} has missing odds")
+        if tip.get("stake") is None:
+            warnings.append(f"\ud83d\udea8 Tip at {race} has missing stake")
+        tags = [str(t).lower() for t in tip.get("tags", [])]
+        if any("nap" in t for t in tags):
+            nap = (name, conf)
+    if nap and nap[1] < 0.8:
+        warnings.append(f"\u26a0\ufe0f NAP confidence is only {nap[1]:.2f} ({nap[0]})")
+    return warnings
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check latest sent tips for common issues"
+    )
+    parser.add_argument(
+        "--logs-dir", default="logs", help="Directory containing sent_tips files"
+    )
+    args = parser.parse_args()
+    latest = find_latest_sent_file(Path(args.logs_dir))
+    tips = load_tips(latest)
+    warns = check_tip_sanity(tips)
+    if warns:
+        for w in warns:
+            print(w)
+    else:
+        print(f"\u2705 No issues found in {latest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/codex_log.md
+++ b/codex_log.md
@@ -446,4 +446,9 @@ error. Added tests for failing responses and documented in changelog.
 **Files Changed:** core/dispatch_tips.py, tippingmonster/helpers.py, cli/tmcli.py, tests/test_tmcli.py, tests/test_dispatch_tips.py, README.md, Docs/monster_overview.md, Docs/CHANGELOG.md, Docs/monster_todo.md, codex_log.md
 **Outcome:** Added `--course` argument to filter tips by racecourse. Updated docs and tests.
 
+## [2025-07-10] Add tip sanity checker
+**Prompt:** Create check_tip_sanity.py to warn about low confidence tips, NAP confidence under 0.8 and missing odds or stake.
+**Files Changed:** check_tip_sanity.py, tests/test_check_tip_sanity.py, Docs/CHANGELOG.md, Docs/monster_overview.md, Docs/monster_todo.md, codex_log.md
+**Outcome:** New script loads the latest sent tips and prints warnings for any issues. Added tests and documentation.
+
 

--- a/tests/test_check_tip_sanity.py
+++ b/tests/test_check_tip_sanity.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from check_tip_sanity import check_tip_sanity
+
+
+def test_warn_low_conf_missing_fields(tmp_path):
+    tips = [
+        {"race": "3:45 Ascot", "name": "A", "confidence": 0.4, "tags": []},
+    ]
+    assert any("Low confidence" in w for w in check_tip_sanity(tips))
+    assert any("missing odds" in w for w in check_tip_sanity(tips))
+    assert any("missing stake" in w for w in check_tip_sanity(tips))
+
+
+def test_warn_nap_confidence(tmp_path):
+    tips = [
+        {
+            "race": "1:00 A",
+            "name": "B",
+            "confidence": 0.9,
+            "bf_sp": 4.0,
+            "stake": 1.0,
+            "tags": [],
+        },
+        {
+            "race": "1:30 A",
+            "name": "C",
+            "confidence": 0.7,
+            "bf_sp": 5.0,
+            "stake": 1.0,
+            "tags": ["Monster NAP"],
+        },
+    ]
+    warns = check_tip_sanity(tips)
+    assert any("NAP confidence" in w for w in warns)


### PR DESCRIPTION
## Summary
- add `check_tip_sanity.py` to warn if sent tips are questionable
- document the new sanity check script
- mark TODO item complete
- log the work in `codex_log.md`
- test `check_tip_sanity`

## Testing
- `pre-commit run --files check_tip_sanity.py tests/test_check_tip_sanity.py Docs/CHANGELOG.md Docs/monster_overview.md Docs/monster_todo.md codex_log.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f73e68308324a8b64f0bbd4c85f1