### PR TITLE
Add backup validator script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ monstertweeter/.env
 tipping-monster-xgb-model.bst
 tipping-monster-xgb-model.bst.gz
 
+backups/

--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - `dispatch_tips.py` accepts `--course` to filter tips by racecourse.
+- `backup_validator.py` ensures timestamped backups for root scripts.
 
 ## 2025-07-09
 

--- a/Docs/monster_todo.md
+++ b/Docs/monster_todo.md
@@ -193,3 +193,4 @@ A living roadmap of every feature, fix, and dream for the Tipping Monster system
 
 
 
+102. ✅ Local backup validator ensures timestamped copies of root scripts [Done: 2025-07-10]

--- a/backup_validator.py
+++ b/backup_validator.py
@@ -1,0 +1,34 @@
+import glob
+import os
+import shutil
+from datetime import datetime
+
+BACKUP_DIR = "backups"
+
+
+def ensure_backup(script_path: str) -> str:
+    """Ensure a timestamped backup exists for the given script."""
+    base_name = os.path.splitext(os.path.basename(script_path))[0]
+    pattern = os.path.join(BACKUP_DIR, f"{base_name}_*.py")
+    existing = glob.glob(pattern)
+    if existing:
+        return f"Already backed up: {os.path.basename(existing[0])}"
+
+    os.makedirs(BACKUP_DIR, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M")
+    dest = os.path.join(BACKUP_DIR, f"{base_name}_{timestamp}.py")
+    shutil.copy2(script_path, dest)
+    return f"Backup created: {os.path.basename(dest)}"
+
+
+def main() -> None:
+    scripts = [f for f in os.listdir(".") if f.endswith(".py")]
+    reports = []
+    for script in scripts:
+        reports.append(ensure_backup(script))
+    for report in reports:
+        print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/codex_log.md
+++ b/codex_log.md
@@ -447,3 +447,8 @@ error. Added tests for failing responses and documented in changelog.
 **Outcome:** Added `--course` argument to filter tips by racecourse. Updated docs and tests.
 
 
+## [2025-07-10] Add backup validator script
+**Prompt:** Backup Validator - ensure root scripts are backed up
+**Files Changed:** backup_validator.py, Docs/CHANGELOG.md, Docs/monster_todo.md, codex_log.md
+**Outcome:** Created timestamped backup tool and updated docs.
+


### PR DESCRIPTION
## Summary
- add backup_validator script to create timestamped copies of root scripts
- ignore `backups/` directory
- document backup validator in CHANGELOG and todo list
- log backup validator addition in codex_log

## Testing
- `pre-commit run --files backup_validator.py Docs/CHANGELOG.md Docs/monster_todo.md codex_log.md .gitignore`
- `pytest tests/test_codex_logger.py::test_log_action_creates_file -q`


------
https://chatgpt.com/codex/tasks/task_e_6849f75006ac8324873f01a2ade4c149