### PR TITLE
Implement Telegram confidence override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ TELEGRAM_CHAT_ID=your-telegram-chat-id
 TELEGRAM_DEV_CHAT_ID=your-telegram-dev-chat-id  # used when TM_DEV=1 (ignored when TM_DEV_MODE=1)
 TM_DEV=1            # route Telegram messages to TELEGRAM_DEV_CHAT_ID
 TM_DEV_MODE=1       # disable Telegram/S3 posts and log locally
+PAUL_TELEGRAM_ID=123456789
 
 # ☁️ AWS S3 (optional, for remote storage/logs)
 AWS_ACCESS_KEY_ID=your-aws-access-key-id

--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -545,6 +545,12 @@
 - Streamlit dashboard shows optional SHAP summary.
 - Training pipeline outputs `features_used.json` with each model.
 
+## 2025-07-11
+
+- Telegram bot now supports `/override_conf`, `/reset_conf` and `/conf_status` to
+  manage confidence thresholds.
+- `dispatch_tips.py` reads `config/conf_override.json` for any active override.
+
 ---
 
 ## [2025-05-31] 🧠 Tipping Monster — Pipeline Stability & Odds Snapshot Cleanup

--- a/Docs/monster_overview.md
+++ b/Docs/monster_overview.md
@@ -216,6 +216,7 @@ All components live and working as intended:
 ✔️ Advised + Level tracked separately  
 ✔️ Telegram summary sent nightly
 ✔️ `/roi` and `/nap` commands available in the Telegram bot
+✔️ `/override_conf`, `/reset_conf`, `/conf_status` manage confidence threshold
 ✔️ Model trained via `train_model_v7.py`
 ✔️ Steam Sniper subsystem *paused*
 ✔️ SHAP feature importance generated for private analysis

--- a/Docs/monster_todo.md
+++ b/Docs/monster_todo.md
@@ -190,6 +190,8 @@ A living roadmap of every feature, fix, and dream for the Tipping Monster system
 
 100. ✅ `--course` option to dispatch tips for a single track [Done: 2025-07-10]
 
+102. ✅ Telegram-based confidence override commands [Done: 2025-07-11]
+
 
 
 

--- a/codex_log.md
+++ b/codex_log.md
@@ -446,4 +446,9 @@ error. Added tests for failing responses and documented in changelog.
 **Files Changed:** core/dispatch_tips.py, tippingmonster/helpers.py, cli/tmcli.py, tests/test_tmcli.py, tests/test_dispatch_tips.py, README.md, Docs/monster_overview.md, Docs/CHANGELOG.md, Docs/monster_todo.md, codex_log.md
 **Outcome:** Added `--course` argument to filter tips by racecourse. Updated docs and tests.
 
+## [2025-07-11] Telegram confidence override
+**Prompt:** Implement Telegram-based override for minimum confidence threshold.
+**Files Changed:** telegram_bot.py, core/dispatch_tips.py, tippingmonster/utils.py, tests/test_conf_override.py, .env.example, Docs/monster_overview.md, Docs/CHANGELOG.md, Docs/monster_todo.md
+**Outcome:** Added `/override_conf`, `/reset_conf`, `/conf_status` commands and override logic applied during dispatch.
+
 

--- a/core/dispatch_tips.py
+++ b/core/dispatch_tips.py
@@ -18,6 +18,7 @@ from core.tip import Tip
 from generate_lay_candidates import standardize_course_only
 from tippingmonster import logs_path, send_telegram_message
 from tippingmonster.env_loader import load_env
+from tippingmonster.utils import load_override_or_default
 from utils.commentary import generate_commentary
 
 load_env()
@@ -327,6 +328,8 @@ def main(argv=None):
     )
     args = parser.parse_args(argv)
 
+    min_conf = load_override_or_default(args.min_conf)
+
     if args.dev:
         os.environ["TM_DEV_MODE"] = "1"
         os.environ["TM_LOG_DIR"] = "logs/dev"
@@ -375,10 +378,10 @@ def main(argv=None):
         )
         odds = tip.get("bf_sp") or tip.get("odds", 0.0)
         stake = calculate_monster_stake(
-            tip.get("confidence", 0.0), odds, min_conf=args.min_conf
+            tip.get("confidence", 0.0), odds, min_conf=min_conf
         )
         if stake == 0.0 and should_skip_by_roi(
-            tip.get("confidence", 0.0), roi_map, args.min_conf
+            tip.get("confidence", 0.0), roi_map, min_conf
         ):
             continue
         if stake == 0.0:

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -13,6 +13,14 @@ from telegram import Update
 from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
 
 from tippingmonster import repo_path
+from tippingmonster.utils import (
+    clear_conf_override,
+    load_override_or_default,
+    set_conf_override,
+)
+
+PAUL_TELEGRAM_ID = int(os.getenv("PAUL_TELEGRAM_ID", "0"))
+DEFAULT_MIN_CONF = 0.80
 
 
 def get_roi_summary(date: str, base_dir: Path | None = None) -> str:
@@ -204,6 +212,9 @@ async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         "/nap [DAYS]",
         "/tip HORSE",
         "/ping",
+        "/override_conf VALUE",
+        "/reset_conf",
+        "/conf_status",
     ]
     await _reply(update, "Available: " + ", ".join(commands))
 
@@ -238,6 +249,52 @@ async def tip(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await _reply(update, message)
 
 
+def _authorised(update: Update) -> bool:
+    return update.effective_user and update.effective_user.id == PAUL_TELEGRAM_ID
+
+
+async def override_conf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not _authorised(update):
+        return
+    if not context.args:
+        await _reply(update, "Usage: /override_conf 0.30")
+        return
+    try:
+        value = float(context.args[0])
+    except ValueError:
+        await _reply(update, "Invalid value")
+        return
+    set_conf_override(value, hours_valid=6)
+    await _reply(update, f"\U0001f513 Confidence override set to {value:.2f}")
+
+
+async def reset_conf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not _authorised(update):
+        return
+    clear_conf_override()
+    await _reply(update, f"\U0001f512 Confidence reset to {DEFAULT_MIN_CONF:.2f}")
+
+
+async def conf_status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    override = load_override_or_default(None)
+    if override is not None:
+        path = repo_path("config", "conf_override.json")
+        try:
+            data = json.loads(path.read_text())
+            expires = data.get("expires")
+        except Exception:
+            expires = "?"
+        await _reply(
+            update,
+            f"\U0001f513 Current min_conf override: {override:.2f} (expires at {expires.split('T')[1] if expires else '?'} )",
+        )
+    else:
+        await _reply(
+            update,
+            f"\U0001f512 Using default confidence threshold: {DEFAULT_MIN_CONF:.2f}",
+        )
+
+
 def main() -> None:
     token = os.getenv("TELEGRAM_BOT_TOKEN")
     if not token:
@@ -250,6 +307,9 @@ def main() -> None:
     application.add_handler(CommandHandler("roi", roi))
     application.add_handler(CommandHandler("nap", nap))
     application.add_handler(CommandHandler("tip", tip))
+    application.add_handler(CommandHandler("override_conf", override_conf))
+    application.add_handler(CommandHandler("reset_conf", reset_conf))
+    application.add_handler(CommandHandler("conf_status", conf_status))
     application.run_polling()
 
 

--- a/tests/test_conf_override.py
+++ b/tests/test_conf_override.py
@@ -1,0 +1,35 @@
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from tippingmonster.utils import (
+    clear_conf_override,
+    load_override_or_default,
+    repo_path,
+    set_conf_override,
+)
+
+
+def test_override_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setenv("TM_ROOT", str(tmp_path))
+    clear_conf_override()
+    default = 0.8
+    assert load_override_or_default(default) == default
+    set_conf_override(0.3, hours_valid=1)
+    assert load_override_or_default(default) == 0.3
+    clear_conf_override()
+    assert load_override_or_default(default) == default
+
+
+def test_override_expiry(tmp_path, monkeypatch):
+    monkeypatch.setenv("TM_ROOT", str(tmp_path))
+    path = repo_path("config", "conf_override.json")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "min_conf_override": 0.25,
+        "expires": (datetime.utcnow() - timedelta(hours=1)).isoformat(),
+    }
+    path.write_text(json.dumps(data))
+    assert load_override_or_default(0.8) == 0.8


### PR DESCRIPTION
## Summary
- add min confidence override helpers
- secure Telegram commands for overriding confidence filter
- apply override during tip dispatch
- document new feature and update task log
- add `.env` example and tests

## Testing
- `pre-commit run --files telegram_bot.py core/dispatch_tips.py tippingmonster/utils.py tests/test_conf_override.py Docs/CHANGELOG.md Docs/monster_overview.md Docs/monster_todo.md codex_log.md .env.example config/.gitkeep`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f7c4a4e883249cbef09dc72aecef