### PR TITLE
Update Telegram env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,9 @@ BF_CERT_DIR=/path/to/cert_directory
 
 # 🤖 Telegram bot credentials
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+TG_BOT_TOKEN=your-telegram-bot-token  # optional alias
 TELEGRAM_CHAT_ID=your-telegram-chat-id
+TG_USER_ID=your-telegram-chat-id      # optional alias
 TELEGRAM_DEV_CHAT_ID=your-telegram-dev-chat-id  # used when TM_DEV=1 (ignored when TM_DEV_MODE=1)
 TM_DEV=1            # route Telegram messages to TELEGRAM_DEV_CHAT_ID
 TM_DEV_MODE=1       # disable Telegram/S3 posts and log locally

--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## 2025-07-15
+
+### Documentation
+- `Docs/README.md` and `.env.example` list `TG_BOT_TOKEN` and `TG_USER_ID`.
+- `Docs/ops.md` clarifies that `safecron.sh` posts failure alerts using these variables.
+
 ## 2025-07-14
 
 ### Changed

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -28,7 +28,9 @@ Create a `.env` file (see `.env.example`) with the following variables:
 - `BF_KEY_PATH`
 - `BF_CERT_DIR`
 - `TELEGRAM_BOT_TOKEN`
+- `TG_BOT_TOKEN` (optional alias for `TELEGRAM_BOT_TOKEN`)
 - `TELEGRAM_CHAT_ID`
+- `TG_USER_ID` (optional alias for `TELEGRAM_CHAT_ID`)
 - `TELEGRAM_DEV_CHAT_ID` (used when `TM_DEV=1`; ignored when `TM_DEV_MODE=1`)
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`

--- a/Docs/monster_todo.md
+++ b/Docs/monster_todo.md
@@ -218,3 +218,6 @@ pt
 107. ✅ Pipeline script initialises `DEV_MODE` from `TM_DEV_MODE` for consistent
      behaviour [Done: 2025-07-14]
 
+108. ✅ Document `TG_BOT_TOKEN` / `TG_USER_ID` env vars and mention safecron
+     failure alerts [Done: 2025-07-15]
+

--- a/Docs/ops.md
+++ b/Docs/ops.md
@@ -14,9 +14,11 @@ The system relies on a series of cron jobs to perform regular tasks. Below is a 
 
 > **Environment Note:** Telegram alerts depend on `TELEGRAM_BOT_TOKEN` and
  > `TELEGRAM_CHAT_ID`. Set these in your `.env` file so all scripts can load them
- > automatically.
- > The `utils/safecron.sh` wrapper respects `TM_DEV_MODE=1` and skips Telegram
- > alerts when enabled.
+> automatically.
+> The `utils/safecron.sh` wrapper respects `TM_DEV_MODE=1` and skips Telegram
+> alerts when enabled.
+> It posts failure alerts using `TG_BOT_TOKEN` and `TG_USER_ID` when jobs exit
+> non-zero.
 
 ---
 

--- a/codex_log.md
+++ b/codex_log.md
@@ -501,4 +501,9 @@ error. Added tests for failing responses and documented in changelog.
 **Files Changed:** core/fetch_betfair_odds.py, Docs/CHANGELOG.md, Docs/monster_todo.md, codex_log.md
 **Outcome:** Added repo root to `sys.path` so the odds fetcher runs inside the CLI pipeline.
 
+## [2025-07-15] Document safecron Telegram vars
+**Prompt:** Update README and `.env.example` to mention `TG_BOT_TOKEN` and `TG_USER_ID` and document failure alerts in `safecron.sh`.
+**Files Changed:** Docs/README.md, Docs/ops.md, .env.example, Docs/CHANGELOG.md, Docs/monster_todo.md, codex_log.md
+**Outcome:** Docs now list the new aliases and explain how `safecron.sh` posts alerts when a cron job fails.
+
 


### PR DESCRIPTION
## Summary
- show TG_BOT_TOKEN and TG_USER_ID aliases in env docs
- highlight that safecron.sh uses these vars on cron failures

## Testing
- `pre-commit run --files Docs/README.md .env.example Docs/ops.md Docs/CHANGELOG.md codex_log.md Docs/monster_todo.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684acc25841883248e851e83b13b07a3