### PR TITLE
Improve combo generator logging and output

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -631,4 +631,12 @@
 - Sample crontab templates for prod and dev under `cron/`.
 - Docs updated to reference `cron/prod.crontab` and `cron/dev.crontab`.
 
+## 2025-07-16
+
+### Added
+- `generate_combos.py` now logs each Telegram post to `logs/roi/combos_DATE.csv`.
+
+### Changed
+- Combo messages include race time, course and odds for each runner.
+
 

--- a/Docs/monster_overview.md
+++ b/Docs/monster_overview.md
@@ -91,7 +91,8 @@ Scripts are grouped under `core/` and `roi/` directories for clarity.
 * `core/merge_odds_into_tips.py`: Adds price info to each runner in the tip file.
 * `core/dispatch_tips.py`: Outputs NAPs, best bets, and high confidence runners into a formatted Telegram message.
 * `core/dispatch_all_tips.py`: Sends every generated tip for a day. Use `--telegram` to post to Telegram and `--batch-size` to control how many tips per message (ensure `TG_USER_ID` is set).
-* `generate_combos.py`: Suggests doubles and trebles from 90%+ confidence tips.
+* `generate_combos.py`: Suggests doubles and trebles from 90%+ confidence tips. Messages
+  include race time, course and odds, and any Telegram posts are logged with ROI.
 * `roi/roi_tracker_advised.py`: Matches tips with results and calculates each-way profit. Also acts as the main daily tracker – filters, calculates profit, generates tip results CSV. Uses the `requests` library to send ROI summaries to Telegram.
 * `roi/calibrate_confidence_daily.py`: Logs ROI by confidence bin (e.g. 0.80–0.90, 0.90–1.00).
 * `roi/weekly_roi_summary.py`: Aggregates weekly tips and profits. Rolls up recent tips into ISO week summaries for weekly ROI.

--- a/Docs/monster_todo.md
+++ b/Docs/monster_todo.md
@@ -218,3 +218,4 @@ pt
 107. ✅ Pipeline script initialises `DEV_MODE` from `TM_DEV_MODE` for consistent
      behaviour [Done: 2025-07-14]
 
+108. ✅ Combo generator logs ROI and shows time/course/odds [Done: 2025-07-16]

--- a/codex_log.md
+++ b/codex_log.md
@@ -506,3 +506,8 @@ error. Added tests for failing responses and documented in changelog.
 **Files Changed:** cron/prod.crontab, cron/dev.crontab, Docs/ops.md, Docs/prod_setup_cheatsheet.md, Docs/quickstart.md, README.md, Docs/CHANGELOG.md, codex_log.md
 **Outcome:** Schedules consolidated into templates and docs updated.
 
+## [2025-07-16] Enhance combo generator
+**Prompt:** Improve `generate_combos.py` to log ROI when posting to Telegram and show odds, times and course.
+**Files Changed:** generate_combos.py, tests/test_generate_combos.py, Docs/CHANGELOG.md, Docs/monster_overview.md, codex_log.md
+**Outcome:** Combo messages now display full race details and are stored in daily ROI logs when sent.
+

--- a/generate_combos.py
+++ b/generate_combos.py
@@ -7,11 +7,11 @@ import json
 import os
 from datetime import date
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from dotenv import load_dotenv
 
-from tippingmonster import send_telegram_message
+from tippingmonster import logs_path, send_telegram_message
 
 load_dotenv()
 
@@ -57,21 +57,120 @@ def combo_multiplier(tips: List[Dict]) -> float:
     return mult
 
 
+def get_race_parts(race: str) -> tuple[str, str]:
+    parts = str(race).split()
+    time = parts[0] if parts else ""
+    course = " ".join(parts[1:]) if len(parts) > 1 else ""
+    return time, course
+
+
+def format_tip(tip: Dict) -> str:
+    time, course = get_race_parts(tip.get("race", ""))
+    odds = tip.get("bf_sp") or tip.get("odds", "?")
+    name = tip.get("name", "?")
+    return f"{time} {course} - {name} @ {odds}"
+
+
 def format_combo(tips: List[Dict]) -> str:
-    names = [t.get("name", "?") for t in tips]
+    parts = [format_tip(t) for t in tips]
     mult = combo_multiplier(tips)
     label = "Double" if len(tips) == 2 else "Treble"
-    return f"\U0001f9e0 Monster {label}: {' + '.join(names)} = {mult:.1f}x"
+    return f"\U0001f9e0 Monster {label}: {' + '.join(parts)} = {mult:.1f}x"
+
+
+def compute_combo_roi(tips: List[Dict], date_str: str) -> Optional[float]:
+    """Return ROI % for ``tips`` if results CSV for ``date_str`` exists."""
+    results_path = Path(f"rpscrape/data/dates/all/{date_str.replace('-', '_')}.csv")
+    if not results_path.exists():
+        return None
+
+    import pandas as pd
+
+    try:
+        df = pd.read_csv(results_path)
+    except Exception:
+        return None
+
+    df.rename(
+        columns={
+            "off": "Race Time",
+            "course": "Course",
+            "horse": "Horse",
+            "pos": "Position",
+            "num": "Runners",
+            "race_name": "Race Name",
+        },
+        inplace=True,
+    )
+    df["Horse"] = df["Horse"].astype(str).str.lower().str.strip()
+    df["Course"] = (
+        df["Course"]
+        .astype(str)
+        .str.lower()
+        .str.strip()
+        .str.replace(r"\s*\(ire\)", "", regex=True)
+    )
+    df["Race Time"] = df["Race Time"].astype(str).str.strip().str.lower()
+
+    results = []
+    for tip in tips:
+        horse = str(tip.get("name", "")).split("(")[0].strip().lower()
+        time, course = get_race_parts(tip.get("race", ""))
+        time = time.lower()
+        course = course.lower().strip()
+        row = df[
+            (df["Horse"] == horse)
+            & (df["Race Time"] == time)
+            & (df["Course"] == course)
+        ]
+        if row.empty:
+            return None
+        pos = str(row["Position"].iloc[0]).strip()
+        results.append(pos == "1")
+
+    stake = 1.0
+    if all(results):
+        profit = combo_multiplier(tips) - 1
+    else:
+        profit = -1.0
+    return round((profit / stake) * 100, 2)
+
+
+def log_combo(tips: List[Dict], date_str: str) -> None:
+    """Append combo details to ROI log."""
+    label = "Double" if len(tips) == 2 else "Treble"
+    roi = compute_combo_roi(tips, date_str)
+    log_path = logs_path("roi", f"combos_{date_str}.csv")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    header = not log_path.exists()
+    row = {
+        "Date": date_str,
+        "Type": label,
+        "Horses": " | ".join(format_tip(t) for t in tips),
+        "Multiplier": round(combo_multiplier(tips), 2),
+        "ROI": "" if roi is None else roi,
+    }
+    import csv
+
+    with open(log_path, "a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=row.keys())
+        if header:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def generate_combos(tips: List[Dict], min_conf: float = 0.90) -> List[List[Dict]]:
+    filtered = filter_high_confidence(tips, min_conf)
+    combos: List[List[Dict]] = []
+    if len(filtered) >= 2:
+        combos.append(filtered[:2])
+    if len(filtered) >= 3:
+        combos.append(filtered[:3])
+    return combos
 
 
 def generate_combo_messages(tips: List[Dict], min_conf: float = 0.90) -> List[str]:
-    filtered = filter_high_confidence(tips, min_conf)
-    messages: List[str] = []
-    if len(filtered) >= 2:
-        messages.append(format_combo(filtered[:2]))
-    if len(filtered) >= 3:
-        messages.append(format_combo(filtered[:3]))
-    return messages
+    return [format_combo(c) for c in generate_combos(tips, min_conf)]
 
 
 def main(argv: List[str] | None = None) -> None:
@@ -95,14 +194,17 @@ def main(argv: List[str] | None = None) -> None:
             return
 
     tips = load_tips(path)
-    messages = generate_combo_messages(tips, args.min_conf)
-    if not messages:
+    combos = generate_combos(tips, args.min_conf)
+    if not combos:
         print("\u26a0\ufe0f No combos generated.")
         return
 
+    messages = [format_combo(c) for c in combos]
     text = "\n".join(messages)
     if args.telegram:
         send_telegram_message(text, token=TELEGRAM_BOT_TOKEN, chat_id=TELEGRAM_CHAT_ID)
+        for combo in combos:
+            log_combo(combo, args.date)
     else:
         print(text)
 

--- a/tests/test_generate_combos.py
+++ b/tests/test_generate_combos.py
@@ -16,7 +16,8 @@ def test_generate_combo_messages_basic():
 
     msgs = generate_combo_messages(tips)
     assert len(msgs) == 2
-    assert "HorseA" in msgs[0] or "HorseD" in msgs[0]
-    assert "HorseB" in msgs[0]
     assert msgs[0].startswith("\U0001f9e0 Monster Double")
+    assert "12:00 A" in msgs[0]
+    assert "HorseB" in msgs[0]
+    assert "@ 5.0" in msgs[0] or "@ 2.0" in msgs[0]
     assert msgs[1].startswith("\U0001f9e0 Monster Treble")


### PR DESCRIPTION
## Summary
- enhance `generate_combos.py` with detailed formatting
- log combo ROI when sending to Telegram
- adjust unit tests for new format
- document changes and mark TODO complete

## Testing
- `pre-commit run --files Docs/CHANGELOG.md Docs/monster_overview.md Docs/monster_todo.md codex_log.md generate_combos.py tests/test_generate_combos.py`
- `pytest tests/test_generate_combos.py`

------
https://chatgpt.com/codex/tasks/task_e_684ae6ced8688324944ae467c1934468