### PR TITLE
Add model output comparison script

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -641,6 +641,7 @@
 
 ### Added
 - `generate_combos.py` now logs each Telegram post to `logs/roi/combos_DATE.csv`.
+- New `compare_model_outputs.py` script compares v6 and v7 predictions on the same racecards.
 
 ### Changed
 - Combo messages include race time, course and odds for each runner.

--- a/Docs/monster_overview.md
+++ b/Docs/monster_overview.md
@@ -283,6 +283,7 @@ feedback loop continually refines accuracy and keeps the weekly insights fresh.
 * Tag-based ROI (ROI breakdown by confidence band, tip type, and tag)
 * ✅ Logic-based commentary blocks (e.g., "📉 Class Drop, 📈 In Form, Conf: 92%")
 * ✅ Parallel model comparison (v6 vs v7)
+* ✅ Output comparison tool `compare_model_outputs.py` to inspect tip differences
 * ✅ Drawdown tracking in ROI logs
 
 ### 🔭 v8+ Expansion (Strategic)

--- a/Docs/monster_todo.md
+++ b/Docs/monster_todo.md
@@ -52,6 +52,7 @@ A living roadmap of every feature, fix, and dream for the Tipping Monster system
 26. Telegram control panel for config (bands, filters)  
 27. ✅ Parallel model comparison (v6 vs v7) *(2025-06-08)*
 28. ✅ Drawdown tracking in ROI logs *(Done: 2025-06-08)*
+29. ✅ Output comparison script `compare_model_outputs.py` *(Done: 2025-07-16)*
 
 ---
 

--- a/Docs/prod_setup_cheatsheet.md
+++ b/Docs/prod_setup_cheatsheet.md
@@ -26,8 +26,9 @@ production deployment.
   - `train_model_v6.py` – base model, optionally use `--self-train` to inject past tips.
   - `core/train_modelv7.py` – always includes tip history features (`was_tipped`,
     `tip_confidence`, `tip_profit`).
-- `compare_model_v6_v7.py` – trains v6 and v7 side by side and writes
-  `logs/compare_model_v6_v7.csv` with ROI for each.
+ - `compare_model_v6_v7.py` – trains v6 and v7 side by side and writes
+   `logs/compare_model_v6_v7.csv` with ROI for each.
+ - `compare_model_outputs.py` – runs both models on the same racecards and logs tip and confidence differences.
 
 ## 3. Training Data
 

--- a/Docs/quickstart.md
+++ b/Docs/quickstart.md
@@ -48,6 +48,7 @@ These times are detailed in `Docs/monster_overview.md`.
 
 - **Training:** `core/train_model_v6.py` and `core/train_modelv7.py` load historical data and produce an XGBoost model.
 - **Model Comparison:** `core/compare_model_v6_v7.py` trains both versions side by side and logs confidence deltas.
+- **Output Comparison:** `compare_model_outputs.py` runs two models on the same racecards and saves the differences in tip selection, confidence and feature impact.
 
 - **Inference:** `core/run_inference_and_select_top1.py` chooses the most recent
   `tipping-monster-xgb-model-*.tar.gz` in the repository root and downloads it

--- a/codex_log.md
+++ b/codex_log.md
@@ -517,3 +517,8 @@ error. Added tests for failing responses and documented in changelog.
 **Files Changed:** generate_combos.py, tests/test_generate_combos.py, Docs/CHANGELOG.md, Docs/monster_overview.md, codex_log.md
 **Outcome:** Combo messages now display full race details and are stored in daily ROI logs when sent.
 
+## [2025-07-16] Model output comparator
+**Prompt:** Build `compare_model_outputs.py` to run two models (v6 vs v7) on same racecards, and log differences in tip selection, confidence, and feature impact.
+**Files Changed:** compare_model_outputs.py, Docs/quickstart.md, Docs/prod_setup_cheatsheet.md, Docs/monster_overview.md, Docs/CHANGELOG.md, Docs/monster_todo.md, codex_log.md
+**Outcome:** New script outputs CSV of v6 vs v7 tips with SHAP summaries.
+

--- a/compare_model_outputs.py
+++ b/compare_model_outputs.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Compare predictions from two model versions on the same racecards."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import tarfile
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import shap
+import xgboost as xgb
+
+from core.model_fetcher import download_if_missing
+
+
+def load_model(tar_path: str) -> tuple[xgb.XGBClassifier, list[str]]:
+    """Extract and load model + feature list from a tarball."""
+    if not os.path.exists(tar_path):
+        bucket = "tipping-monster"
+        local_name = os.path.basename(tar_path)
+        download_if_missing(bucket, tar_path, local_name)
+        tar_path = local_name
+    tmpdir = tempfile.mkdtemp()
+    with tarfile.open(tar_path, "r:gz") as tar:
+        tar.extractall(tmpdir)
+    model_file = Path(tmpdir) / "tipping-monster-xgb-model.bst"
+    features_file = Path(tmpdir) / "features.json"
+    with open(features_file) as f:
+        features = json.load(f)
+    model = xgb.XGBClassifier()
+    model.load_model(model_file)
+    return model, features
+
+
+def load_data(path: str) -> pd.DataFrame:
+    """Load flattened racecards from JSONL."""
+    paths = sorted(glob.glob(path))
+    if not paths:
+        raise FileNotFoundError(f"No input files match {path}")
+    frames = []
+    for p in paths:
+        with open(p) as f:
+            rows = [json.loads(line) for line in f]
+        frames.append(pd.DataFrame(rows))
+    return pd.concat(frames, ignore_index=True)
+
+
+def predict(
+    df: pd.DataFrame, model: xgb.XGBClassifier, features: list[str]
+) -> pd.Series:
+    X = df[features].apply(pd.to_numeric, errors="coerce").fillna(-1)
+    return pd.Series(model.predict_proba(X)[:, 1], index=df.index)
+
+
+def shap_summary(
+    model: xgb.XGBClassifier, X: pd.DataFrame, features: list[str], top_n: int = 3
+) -> str:
+    explainer = shap.TreeExplainer(model)
+    values = explainer.shap_values(X)[0]
+    idx = np.argsort(np.abs(values))[-top_n:][::-1]
+    parts = [f"{features[i]}:{values[i]:+.2f}" for i in idx]
+    return ", ".join(parts)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare two model outputs")
+    parser.add_argument(
+        "--model-v6", required=True, help="Path or S3 key for v6 model tar.gz"
+    )
+    parser.add_argument(
+        "--model-v7", required=True, help="Path or S3 key for v7 model tar.gz"
+    )
+    parser.add_argument(
+        "--input", required=True, help="Flattened racecards JSONL pattern"
+    )
+    parser.add_argument(
+        "--out", default="logs/compare_model_outputs.csv", help="Output CSV path"
+    )
+    args = parser.parse_args()
+
+    df = load_data(args.input)
+
+    model_v6, feats_v6 = load_model(args.model_v6)
+    model_v7, feats_v7 = load_model(args.model_v7)
+
+    df["v6_conf"] = predict(df, model_v6, feats_v6)
+    df["v7_conf"] = predict(df, model_v7, feats_v7)
+
+    rows = []
+    for race, race_df in df.groupby("race"):
+        top_v6 = race_df.loc[race_df["v6_conf"].idxmax()]
+        top_v7 = race_df.loc[race_df["v7_conf"].idxmax()]
+        shap_v6 = shap_summary(model_v6, top_v6[feats_v6].to_frame().T, feats_v6)
+        shap_v7 = shap_summary(model_v7, top_v7[feats_v7].to_frame().T, feats_v7)
+        rows.append(
+            {
+                "Race": race,
+                "Tip_v6": top_v6["name"],
+                "Conf_v6": top_v6["v6_conf"],
+                "Tip_v7": top_v7["name"],
+                "Conf_v7": top_v7["v7_conf"],
+                "Delta": top_v7["v7_conf"] - top_v6["v6_conf"],
+                "Same": top_v6["name"] == top_v7["name"],
+                "Features_v6": shap_v6,
+                "Features_v7": shap_v7,
+            }
+        )
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_csv(out_path, index=False)
+    print(f"✅ Saved comparison to {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `compare_model_outputs.py` to compare v6 and v7 predictions
- document output comparison script in quickstart and production cheat sheet
- record new script in the overview, todo list and CHANGELOG
- log the change in `codex_log.md`

## Testing
- `pre-commit run --files compare_model_outputs.py Docs/quickstart.md Docs/prod_setup_cheatsheet.md Docs/CHANGELOG.md Docs/monster_overview.md Docs/monster_todo.md codex_log.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b169fe12483249455cb6ad4734196