### PR TITLE
Add drawdown streak tracking

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -645,4 +645,12 @@
 ### Changed
 - Combo messages include race time, course and odds for each runner.
 
+## 2025-07-17
+
+### Added
+- ROI tracker logs drawdown streak metrics (`logs/drawdown_stats.csv`).
+
+### Changed
+- Daily ROI summary shows current losing run, longest streak and max drawdown.
+
 

--- a/Docs/monster_overview.md
+++ b/Docs/monster_overview.md
@@ -40,6 +40,7 @@ These core functionalities are currently **deployed and operating seamlessly** w
 * ✅ Each-Way Profit Logic: Accurate Each-Way profit calculation based on fluctuating odds
 * ✅ Financial Tracking: Comprehensive bankroll tracker with detailed CSV logs
 * ✅ Drawdown Metrics: Daily and weekly ROI logs show bankroll and worst drawdown
+* ✅ Drawdown Streaks: Tracker logs longest losing run and max DD in `drawdown_stats.csv`
 * ✅ Tip Summaries: Automated creation of `tips_summary.txt` files
 * ✅ Matching Accuracy: Enhanced fuzzy horse name matching and time alignment for precise result linking
 

--- a/Docs/monster_todo.md
+++ b/Docs/monster_todo.md
@@ -52,6 +52,7 @@ A living roadmap of every feature, fix, and dream for the Tipping Monster system
 26. Telegram control panel for config (bands, filters)  
 27. ✅ Parallel model comparison (v6 vs v7) *(2025-06-08)*
 28. ✅ Drawdown tracking in ROI logs *(Done: 2025-06-08)*
+29. ✅ Drawdown streak metrics logged *(Done: 2025-07-17)*
 
 ---
 

--- a/codex_log.md
+++ b/codex_log.md
@@ -517,3 +517,8 @@ error. Added tests for failing responses and documented in changelog.
 **Files Changed:** generate_combos.py, tests/test_generate_combos.py, Docs/CHANGELOG.md, Docs/monster_overview.md, codex_log.md
 **Outcome:** Combo messages now display full race details and are stored in daily ROI logs when sent.
 
+## [2025-07-17] Track drawdown streaks
+**Prompt:** Extend the ROI tracker to log drawdown streaks — longest losing streak, current losing run, max drawdown in points. Save to `logs/drawdown_stats.csv`.
+**Files Changed:** roi/roi_tracker_advised.py, tests/test_drawdown_stats.py, Docs/CHANGELOG.md, Docs/monster_overview.md, Docs/monster_todo.md, codex_log.md
+**Outcome:** ROI summary now prints drawdown streak info and updates `drawdown_stats.csv` daily.
+

--- a/roi/roi_tracker_advised.py
+++ b/roi/roi_tracker_advised.py
@@ -23,6 +23,7 @@ from tippingmonster import (
 # isort: on
 
 BANKROLL_FILE = logs_path("roi", "bankroll_tracker.csv")
+DRAWDOWN_STATS_FILE = logs_path("drawdown_stats.csv")
 
 
 def load_bankroll() -> pd.DataFrame:
@@ -67,6 +68,36 @@ def update_bankroll(date: str, profit: float, stake: float) -> dict:
 
     df = pd.concat([df, pd.DataFrame([row])], ignore_index=True)
     df.to_csv(BANKROLL_FILE, index=False)
+    return row
+
+
+def load_drawdown_stats() -> pd.DataFrame:
+    if os.path.exists(DRAWDOWN_STATS_FILE):
+        return pd.read_csv(DRAWDOWN_STATS_FILE)
+    return pd.DataFrame(
+        columns=["Date", "CurrentLosingRun", "LongestLosingRun", "MaxDrawdown"]
+    )
+
+
+def update_drawdown_stats(date: str, profit: float, worst_drawdown: float) -> dict:
+    df = load_drawdown_stats()
+    prev_current = int(df["CurrentLosingRun"].iloc[-1]) if not df.empty else 0
+    prev_longest = int(df["LongestLosingRun"].iloc[-1]) if not df.empty else 0
+    prev_max = float(df["MaxDrawdown"].iloc[-1]) if not df.empty else 0.0
+
+    current = prev_current + 1 if profit < 0 else 0
+    longest = max(prev_longest, current)
+    max_dd = max(prev_max, abs(worst_drawdown))
+
+    row = {
+        "Date": date,
+        "CurrentLosingRun": current,
+        "LongestLosingRun": longest,
+        "MaxDrawdown": max_dd,
+    }
+    df = pd.concat([df, pd.DataFrame([row])], ignore_index=True)
+    Path(DRAWDOWN_STATS_FILE).parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(DRAWDOWN_STATS_FILE, index=False)
     return row
 
 
@@ -234,11 +265,21 @@ def main(date_str, mode, min_conf, send_to_telegram, use_sent, show=False, tag=N
     drawdown = bankroll_row.get("Drawdown", 0.0)
     worst_dd = bankroll_row.get("WorstDrawdown", 0.0)
 
+    if show:
+        dd_df = load_drawdown_stats()
+        if dd_df.empty:
+            dd_row = {"CurrentLosingRun": 0, "LongestLosingRun": 0, "MaxDrawdown": 0.0}
+        else:
+            dd_row = dd_df.iloc[-1].to_dict()
+    else:
+        dd_row = update_drawdown_stats(summary["Date"], summary["Profit"], worst_dd)
+
     result_line = (
         f"{summary['Date']}   Tips: {summary['Tips']}    Wins: {summary['Wins']}   "
         f"Places: {summary['Places']}   NRs: {summary['NRs']}   Stake: {summary['Stake']:.2f} "
         f"Profit: {summary['Profit']:.2f} ROI: {roi:.2f}%   "
-        f"Bankroll: {bankroll:+.2f} Drawdown: {drawdown:.2f} (Worst {worst_dd:.2f})"
+        f"Bankroll: {bankroll:+.2f} Drawdown: {drawdown:.2f} (Worst {worst_dd:.2f})   "
+        f"Run: {dd_row['CurrentLosingRun']} (Longest {dd_row['LongestLosingRun']}) MaxDD: {dd_row['MaxDrawdown']:.2f}"
     )
     print(result_line)
 
@@ -272,6 +313,8 @@ def main(date_str, mode, min_conf, send_to_telegram, use_sent, show=False, tag=N
 📈 ROI: {roi:.2f}%
 💰 Bankroll: {bankroll:+.2f} pts
 🔻 Drawdown: {drawdown:.2f} (Worst {worst_dd:.2f})
+📉 Run: {dd_row['CurrentLosingRun']} (Longest {dd_row['LongestLosingRun']})
+📉 Max DD: {dd_row['MaxDrawdown']:.2f} pts
 🪙 Staked: {summary['Stake']:.2f} pts"""
         send_telegram_message(message)
 

--- a/tests/test_drawdown_stats.py
+++ b/tests/test_drawdown_stats.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_drawdown_updates(tmp_path, monkeypatch):
+    monkeypatch.setenv("TM_ROOT", str(tmp_path))
+    import importlib
+
+    import tippingmonster.utils as utils
+
+    importlib.reload(utils)
+    from roi import roi_tracker_advised as rta
+
+    importlib.reload(rta)
+
+    row1 = rta.update_drawdown_stats("2025-06-01", -1.0, -1.0)
+    assert row1["CurrentLosingRun"] == 1
+    assert row1["LongestLosingRun"] == 1
+    assert row1["MaxDrawdown"] == 1.0
+
+    row2 = rta.update_drawdown_stats("2025-06-02", -2.0, -3.0)
+    assert row2["CurrentLosingRun"] == 2
+    assert row2["LongestLosingRun"] == 2
+    assert row2["MaxDrawdown"] == 3.0
+
+    row3 = rta.update_drawdown_stats("2025-06-03", 1.0, -2.0)
+    assert row3["CurrentLosingRun"] == 0
+    assert row3["LongestLosingRun"] == 2
+    assert row3["MaxDrawdown"] == 3.0
+
+    df = rta.load_drawdown_stats()
+    assert len(df) == 3


### PR DESCRIPTION
## Summary
- extend `roi_tracker_advised` with drawdown streak logging
- store results in `logs/drawdown_stats.csv`
- show streak stats in CLI and Telegram output
- cover new logic with `test_drawdown_stats`
- document feature in overview, todo and changelog

## Testing
- `pre-commit run --files roi/roi_tracker_advised.py tests/test_drawdown_stats.py Docs/CHANGELOG.md Docs/monster_overview.md Docs/monster_todo.md codex_log.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b16ac7184832489b3dd9cf59cb3f0