### PR TITLE
Add Telegram variable reference docs

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -646,3 +646,10 @@
 - Combo messages include race time, course and odds for each runner.
 
 
+
+## 2025-07-17
+
+### Documentation
+- Added `Docs/telegram_alerts.md` summarising Telegram environment variables and their usage.
+- `Docs/README.md` links to the new reference.
+

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -43,6 +43,7 @@ Set `TM_DEV_MODE=1` to suppress all Telegram sends and write to `logs/dev/` inst
 Running scripts with the `--dev` flag automatically sets `TM_DEV_MODE=1`.
 The `utils/safecron.sh` helper also respects this variable and will not send
 Telegram alerts when `TM_DEV_MODE=1`.
+See `telegram_alerts.md` for a full list of Telegram variables and the scripts that use them.
 
 You can copy `.env.example` to `.env` and fill in your credentials for local development.
 

--- a/Docs/telegram_alerts.md
+++ b/Docs/telegram_alerts.md
@@ -1,0 +1,27 @@
+# Telegram Alerts
+
+This guide summarises all environment variables related to Telegram notifications and which scripts use them.
+
+## Environment variables
+
+- `TELEGRAM_BOT_TOKEN` / `TG_BOT_TOKEN` – bot token used for all Telegram messages.
+- `TELEGRAM_CHAT_ID` / `TG_USER_ID` – default chat ID to receive messages.
+- `TELEGRAM_DEV_CHAT_ID` – alternate chat ID when `TM_DEV=1`.
+- `PAUL_TELEGRAM_ID` – authorisation ID for privileged bot commands.
+- `TM_DEV` – routes Telegram posts to `TELEGRAM_DEV_CHAT_ID`.
+- `TM_DEV_MODE` – when set to `1`, suppresses Telegram posts and logs them to `logs/dev/` instead.
+
+## Scripts and messages
+
+- **tippingmonster/utils.py** implements `send_telegram_message` and `send_telegram_photo`. These helpers load the bot token and chat ID, honour `TM_DEV` and `TM_DEV_MODE` and are called by most scripts.
+- **core/dispatch_tips.py** and **core/dispatch_all_tips.py** send the day's tips.
+- **dispatch_danger_favs.py** posts daily danger-favourite alerts.
+- **generate_combos.py**, **generate_lay_candidates.py**, **track_lay_candidates_roi.py** and **roi/*.py** scripts send ROI summaries and combo updates.
+- **model_feature_importance.py** and **tip_control_panel.py** post images or interactive messages.
+- **telegram_bot.py** runs the interactive bot using `TELEGRAM_BOT_TOKEN` and restricts `/override_conf` and other admin commands to `PAUL_TELEGRAM_ID`.
+- **utils/safecron.sh** posts cron failure alerts with `TG_BOT_TOKEN` and `TG_USER_ID` when a job exits non‑zero.
+
+## Cron failure alerts
+
+`safecron.sh` captures the last lines of the job log and sends an alert if the exit code is non‑zero. Alerts are skipped when `TM_DEV_MODE=1`.
+

--- a/codex_log.md
+++ b/codex_log.md
@@ -517,3 +517,7 @@ error. Added tests for failing responses and documented in changelog.
 **Files Changed:** generate_combos.py, tests/test_generate_combos.py, Docs/CHANGELOG.md, Docs/monster_overview.md, codex_log.md
 **Outcome:** Combo messages now display full race details and are stored in daily ROI logs when sent.
 
+## [2025-07-17] Document Telegram env vars
+**Prompt:** Create a reference doc for Telegram variables and link it from README.
+**Files Changed:** Docs/telegram_alerts.md, Docs/README.md, Docs/CHANGELOG.md, codex_log.md
+**Outcome:** New doc lists all Telegram variables, shows which scripts use them and notes safecron alerts.


### PR DESCRIPTION
## Summary
- document all Telegram environment variables in a new doc
- link the doc from `Docs/README.md`
- note the addition in `Docs/CHANGELOG.md`

## Testing
- `pre-commit run --files Docs/CHANGELOG.md Docs/README.md Docs/telegram_alerts.md codex_log.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b1715d50c832492ee0ab40a4c21d5