### PR TITLE
Add place probability support

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -645,4 +645,11 @@
 ### Changed
 - Combo messages include race time, course and odds for each runner.
 
+## 2025-07-17
+
+### Added
+- `run_inference_and_select_top1.py` loads an optional meta place model and
+  outputs `final_place_confidence` per runner.
+- `dispatch_tips.py` displays a "Place Chance" line when this value is present.
+
 

--- a/Docs/monster_overview.md
+++ b/Docs/monster_overview.md
@@ -87,6 +87,8 @@ Scripts are grouped under `core/` and `roi/` directories for clarity.
 
 * `train_model_v7.py`: Default training script using XGBoost with rating, class, form, trainer, jockey, etc.
 * `train_place_model.py`: Predicts whether a runner finishes in the top 3 using the same feature set.
+* The optional **meta place model** combines core features to output
+  `final_place_confidence` during inference.
 * `python -m core.run_inference_and_select_top1`: Uses the model to predict a winner per race with confidence scores. Run it from the repo root (or add the repo root to `PYTHONPATH`) so it can locate the `core` package.
 * `core/merge_odds_into_tips.py`: Adds price info to each runner in the tip file.
 * `core/dispatch_tips.py`: Outputs NAPs, best bets, and high confidence runners into a formatted Telegram message.

--- a/Docs/monster_todo.md
+++ b/Docs/monster_todo.md
@@ -224,4 +224,7 @@ pt
 108. ✅ Document `TG_BOT_TOKEN` / `TG_USER_ID` env vars and mention safecron
      failure alerts [Done: 2025-07-15]
 
+109. ✅ Meta place model outputs `final_place_confidence` for each tip
+    [Done: 2025-07-17]
+
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Tips under **0.80** confidence are automatically skipped unless their confidence
 band showed a positive ROI in the last 30 days (tracked in
 `monster_confidence_per_day_with_roi.csv`).
 
+If the optional *meta place model* is present, each tip also includes a
+`final_place_confidence` value summarised in the Telegram message as
+"Place Chance".
+
 The Streamlit P&L dashboard includes a *Positive ROI Bands Only* checkbox that
 uses this same file to filter tips.
 

--- a/codex_log.md
+++ b/codex_log.md
@@ -517,3 +517,8 @@ error. Added tests for failing responses and documented in changelog.
 **Files Changed:** generate_combos.py, tests/test_generate_combos.py, Docs/CHANGELOG.md, Docs/monster_overview.md, codex_log.md
 **Outcome:** Combo messages now display full race details and are stored in daily ROI logs when sent.
 
+## [2025-07-17] Add place confidence output
+**Prompt:** Generate `final_place_confidence` using the meta-place model and show it in Telegram tips.
+**Files Changed:** core/run_inference_and_select_top1.py, core/dispatch_tips.py, tests/test_run_inference_and_select_top1.py, tests/test_dispatch_tips.py, Docs/CHANGELOG.md, Docs/monster_overview.md, Docs/monster_todo.md, README.md, codex_log.md
+**Outcome:** Inference writes a place probability for each runner and Telegram messages include a "Place Chance" line when available.
+

--- a/core/dispatch_tips.py
+++ b/core/dispatch_tips.py
@@ -159,6 +159,14 @@ def build_confidence_line(tip: dict) -> str:
     return f"\ud83e\udde0 Model Confidence: {level} ({conf_pct}%){suffix}."
 
 
+def build_place_line(tip: dict) -> str | None:
+    place_conf = tip.get("final_place_confidence")
+    if place_conf is None:
+        return None
+    pct = round(place_conf * 100)
+    return f"\ud83c\udfc5 Place Chance: {pct}%"
+
+
 def get_confidence_band(conf: float) -> str | None:
     """Return the confidence band label for ``conf`` or ``None`` if out of range."""
     bins = [
@@ -283,7 +291,11 @@ def format_tip_message(tip, max_id):
     explain = tip.get("explanation")
     explain_line = f"💡 Why we tipped this: {explain}" if explain else ""
     confidence_line = build_confidence_line(tip)
-    parts = [header, title, stats, confidence_line, tags, comment]
+    place_line = build_place_line(tip)
+    parts = [header, title, stats, confidence_line]
+    if place_line:
+        parts.append(place_line)
+    parts.extend([tags, comment])
     if explain_line:
         parts.append(explain_line)
     parts.append("-" * 30)

--- a/tests/test_dispatch_tips.py
+++ b/tests/test_dispatch_tips.py
@@ -7,6 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from core.dispatch_tips import (
     calculate_monster_stake,
     build_confidence_line,
+    build_place_line,
     generate_tags,
     get_tip_composite_id,
     load_recent_roi_stats,
@@ -166,6 +167,16 @@ def test_build_confidence_line_basic():
     line = build_confidence_line(tip)
     assert line.startswith("\ud83e\udde0 Model Confidence: High (92%)")
     assert "class drop" in line and "fresh" in line
+
+
+def test_build_place_line():
+    tip = {"final_place_confidence": 0.73}
+    line = build_place_line(tip)
+    assert line == "\ud83c\udfc5 Place Chance: 73%"
+
+
+def test_build_place_line_none():
+    assert build_place_line({}) is None
 
 
 def test_filter_tips_by_course():


### PR DESCRIPTION
## Summary
- load optional meta place model and compute `final_place_confidence`
- show "Place Chance" line in Telegram tips
- document new field in overview, README and changelog
- update todo list and codex log
- extend unit tests for new behaviour

## Testing
- `pre-commit run --files core/run_inference_and_select_top1.py core/dispatch_tips.py tests/test_dispatch_tips.py tests/test_run_inference_and_select_top1.py README.md Docs/CHANGELOG.md Docs/monster_overview.md Docs/monster_todo.md codex_log.md`
- `pytest -q tests/test_dispatch_tips.py tests/test_run_inference_and_select_top1.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d62e187888324bf09ba60d29c3d8f