### PR TITLE
Update docs for v8 inference script

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## 2025-07-17
+
+### Documentation
+- `Docs/monster_overview.md` lists the new `run_inference_monster_v8.py` and `compare_model_outputs.py` scripts.
+- `all_scripts.txt` updated with both filenames.
+
 ## 2025-07-15
 
 ### Documentation

--- a/Docs/monster_overview.md
+++ b/Docs/monster_overview.md
@@ -104,6 +104,8 @@ Scripts are grouped under `core/` and `roi/` directories for clarity.
 * `core/trainer_stable_profile.py`: Computes 30-day win rate and ROI per trainer.
 * `trainer_intent_profiler.py`: Adds stable-form tags to tips based on recent performance.
 * `check_tip_sanity.py`: Warns if the latest sent tips have low confidence or missing odds/stake.
+* `run_inference_monster_v8.py`: Runs the experimental v8 model and outputs tips with confidence scores.
+* `compare_model_outputs.py`: Produces side-by-side comparisons of model predictions and ROI.
 
 ---
 

--- a/all_scripts.txt
+++ b/all_scripts.txt
@@ -40,3 +40,5 @@ streamlit_pauls_view.py
 generate_rolling_roi.py
 public_dashboard.py
 simulate_staking.py
+run_inference_monster_v8.py
+compare_model_outputs.py

--- a/codex_log.md
+++ b/codex_log.md
@@ -517,3 +517,8 @@ error. Added tests for failing responses and documented in changelog.
 **Files Changed:** generate_combos.py, tests/test_generate_combos.py, Docs/CHANGELOG.md, Docs/monster_overview.md, codex_log.md
 **Outcome:** Combo messages now display full race details and are stored in daily ROI logs when sent.
 
+## [2025-07-17] Document new v8 inference script
+**Prompt:** Add short docs for `run_inference_monster_v8.py` and `compare_model_outputs.py` and list them in `all_scripts.txt`.
+**Files Changed:** Docs/monster_overview.md, all_scripts.txt, Docs/CHANGELOG.md, codex_log.md
+**Outcome:** Overview section includes both scripts and script index updated.
+


### PR DESCRIPTION
## Summary
- mention `run_inference_monster_v8.py` and `compare_model_outputs.py` in the script overview
- add both files to `all_scripts.txt`
- document the change

## Testing
- `pre-commit run --files Docs/CHANGELOG.md Docs/monster_overview.md all_scripts.txt codex_log.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d62e2e6148324839bbebc81fbd5e7