### PR TITLE
Update docs with v8 ensemble workflow

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -721,3 +721,20 @@
 ### Documentation
 - `Docs/monster_overview.md` lists `run_inference_monster_v8.py` and `compare_model_outputs.py` with usage notes.
 
+## 2025-07-19
+
+### Documentation
+- README and Quickstart highlight the experimental v8 training and inference scripts.
+- `Docs/model_storage.md` references `monster_v8_stack.tar.gz` tarball.
+- `Docs/README.md` lists `run_inference_monster_v8.py` as an included document.
+
+
+## 2025-07-20
+
+### Fixed
+- Restored missing helper functions in `core/run_inference_and_select_top1.py` so tests pass again.
+
+## 2025-07-21
+
+### Documentation
+- Added explicit command for `train_monster_model_v8.py` in README and Quickstart.

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -12,6 +12,7 @@ This documentation set covers everything about the **Tipping Monster** project �
 - `monster_todo_v2.md` – high-level roadmap for upcoming features.
 - `dev_command_reference.md` – quick list of useful developer commands.
 - `prod_setup_cheatsheet.md` – dev-to-prod reference.
+- `run_inference_monster_v8.py` – stacked ensemble inference for the experimental v8 model.
  - `../Docs/script_audit.txt` – summary of active vs. unused scripts with keep/remove/rewrite verdicts.
  - `../Docs/SECURITY_REVIEW.md` – latest security audit notes.
 

--- a/Docs/model_storage.md
+++ b/Docs/model_storage.md
@@ -35,7 +35,8 @@ The inference script `run_inference_and_select_top1.py` automatically selects
 the most recent `tipping-monster-xgb-model-*.tar.gz` in the repository root. If
 no tarball is found, it exits with `FileNotFoundError: No model tarball found.
 Download one from S3 or run training.` When a path or S3 key is provided via
-`--model`, the script downloads that file if missing locally.
+`--model`, the file is downloaded if missing. The v8 ensemble workflow follows
+the same pattern with `models/monster_v8_stack.tar.gz`.
 
 
 Large model files are tracked with **Git LFS**. If you clone the repository with

--- a/Docs/quickstart.md
+++ b/Docs/quickstart.md
@@ -54,6 +54,11 @@ These times are detailed in `Docs/monster_overview.md`.
   `tipping-monster-xgb-model-*.tar.gz` in the repository root and downloads it
   from S3 if a path is provided. If no model is available, the script exits with
   `FileNotFoundError`.
+- **v8 Ensemble Training:** `core/train_monster_model_v8.py` builds the stacked
+  model and saves `models/monster_v8_stack.tar.gz`.
+- **v8 Ensemble Inference:** `core/run_inference_monster_v8.py` loads
+  `models/monster_v8_stack.tar.gz` (downloaded on demand) and writes
+  predictions to `predictions/<DATE>/output_v8.jsonl`.
 - **Important:** run this script from the **repository root**:
 
 ```bash
@@ -70,7 +75,7 @@ Running it while inside `core/` triggers a `ModuleNotFoundError` unless the repo
 1. **Read through `Docs/monster_overview.md`** to understand the full pipeline and feature set.
 2. **Consult `Docs/ops.md`** for cron schedules and log locations. Ready-to-use
    templates live in `cron/prod.crontab` and `cron/dev.crontab`.
-3. Explore the training (`core/train_model_v6.py`) and inference (`python -m core.run_inference_and_select_top1`) scripts to see how predictions are generated. If you run the inference script by path, ensure the repo root is on `PYTHONPATH` or use the module form above.
+3. Explore the training scripts (`core/train_model_v6.py` and the experimental `train_monster_model_v8.py`) and their matching inference commands (`python -m core.run_inference_and_select_top1` or `python -m core.run_inference_monster_v8`). If you run these by path, ensure the repo root is on `PYTHONPATH` or use the module form above.
 4. Review the ROI scripts (e.g., `roi/roi_tracker_advised.py`) and `roi/run_roi_pipeline.sh` to understand profit tracking.
 5. Check the TODO lists in `Docs/monster_todo.md` and `Docs/TIPPING_MONSTER_ROI_TODO.md` for future work items.
 6. Run `./utils/dev-check.sh` followed by `make test` to verify your setup.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,14 @@ repository root. If no model is found, they exit with `FileNotFoundError` and
 instruct you to download one from S3 or train locally. When a path is provided
 via `--model`, that file is downloaded if missing locally.
 
+### v8 Stacked Ensemble (Experimental)
+
+The latest research pipeline trains an ensemble of CatBoost, XGBoost and a small
+Keras MLP. Run `python core/train_monster_model_v8.py` to generate
+`models/monster_v8_stack.tar.gz`, which is uploaded to the `tipping-monster` S3
+bucket. Use `python -m core.run_inference_monster_v8 --input <racecards.jsonl>`
+to produce tips under `predictions/<DATE>/output_v8.jsonl`.
+
 ## Model Transparency and Self‑Training
 
 The pipeline uses **SHAP** to compute feature importance for each prediction. These explanations

--- a/codex_log.md
+++ b/codex_log.md
@@ -590,4 +590,19 @@ error. Added tests for failing responses and documented in changelog.
 **Files Changed:** Docs/monster_overview.md, Docs/CHANGELOG.md, codex_log.md
 **Outcome:** Overview now mentions the v8 inference script and the output comparator with typical usage guidance.
 
+## [2025-07-19] Clarify v8 workflow docs
+**Prompt:** User noted missing v8 references. Add documentation about the stacked ensemble scripts and update README, quickstart and model storage notes.
+**Files Changed:** README.md, Docs/quickstart.md, Docs/model_storage.md, Docs/README.md, Docs/CHANGELOG.md, codex_log.md
+**Outcome:** Repo docs now explain how to train and run the v8 stack and where the tarball is stored.
 
+
+
+## [2025-07-20] Fix inference helper imports
+**Prompt:** Tests failed due to missing `extract_race_sort_key` in `run_inference_and_select_top1.py`.
+**Files Changed:** core/run_inference_and_select_top1.py, Docs/CHANGELOG.md
+**Outcome:** Restored helper functions and tests pass.
+
+## [2025-07-21] Clarify v8 training docs
+**Prompt:** Addressed user feedback about missing v8 instructions. Added training command for the stacked ensemble to README and Quickstart.
+**Files Changed:** README.md, Docs/quickstart.md, Docs/CHANGELOG.md, codex_log.md
+**Outcome:** Documentation now spells out how to run `train_monster_model_v8.py`.

--- a/core/run_inference_and_select_top1.py
+++ b/core/run_inference_and_select_top1.py
@@ -24,7 +24,168 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from core.model_fetcher import download_if_missing
 from tippingmonster.env_loader import load_env
 
-# ... [KEEP ALL YOUR EXISTING FUNCTION DEFINITIONS HERE: generate_reason, generate_tags, make_json_safe, load_combined_results, get_last_class, extract_race_sort_key] ...
+
+def generate_reason(tip: dict) -> str:
+    reason = []
+    try:
+        if float(tip.get("trainer_rtf", 0)) >= 25:
+            reason.append("yard in form")
+    except Exception:
+        pass
+    try:
+        days = float(tip.get("days_since_run", 999))
+        if 7 <= days <= 14:
+            reason.append("fresh off a short break")
+        elif days > 180:
+            reason.append("returning from a layoff")
+    except Exception:
+        pass
+    try:
+        if float(tip.get("last_class", -1)) > float(tip.get("class", -1)):
+            reason.append("down in class")
+    except Exception:
+        pass
+    try:
+        form = float(tip.get("form_score", 0))
+        if form >= 20:
+            reason.append("strong recent form")
+    except Exception:
+        pass
+    try:
+        draw = int(tip.get("draw", -1))
+        distance = float(tip.get("dist_f", 99))
+        draw_bias = float(tip.get("draw_bias_rank", 1.0))
+        if draw > 0 and distance <= 16 and draw_bias < 0.4:
+            reason.append("good draw position")
+        if draw_bias > 0.7:
+            reason.append("draw advantage")
+    except Exception:
+        pass
+    if reason:
+        return "✍️ " + ", ".join(reason) + "."
+    else:
+        return "💬 Monster likes it — data suggests an edge."
+
+
+def generate_tags(tip: dict) -> list[str]:
+    tags: list[str] = []
+    try:
+        rtf = float(tip.get("trainer_rtf", 0))
+        if rtf >= 20:
+            tags.append(f"🔥 Trainer {int(rtf)}%")
+    except Exception:
+        pass
+    try:
+        if float(tip.get("last_class", -1)) > float(tip.get("class", -1)):
+            tags.append("🟢 Class Drop")
+    except Exception:
+        pass
+    try:
+        days = float(tip.get("days_since_run", 999))
+        if 7 <= days <= 14:
+            tags.append("⚡ Fresh")
+        elif days > 180:
+            tags.append("🚫 Layoff")
+    except Exception:
+        pass
+    try:
+        if float(tip.get("lbs", 999)) < 135:
+            tags.append("⚖️ Light Weight")
+    except Exception:
+        pass
+    try:
+        if float(tip.get("form_score", 0)) >= 20:
+            tags.append("📈 In Form")
+    except Exception:
+        pass
+    try:
+        if float(tip.get("draw_bias_rank", 0)) > 0.7:
+            tags.append("📊 Draw Advantage")
+    except Exception:
+        pass
+    tip_conf = tip.get("confidence", 0)
+    global_max_conf = tip.get("global_max_confidence", 0)
+    if tip_conf == global_max_conf:
+        tags.append("🧠 Monster NAP")
+    if tip_conf >= 0.90:
+        tags.append("❗ Confidence 90%+")
+    return tags
+
+
+def make_json_safe(obj):
+    if isinstance(obj, (np.float32, np.float64)):
+        return float(obj)
+    elif isinstance(obj, (np.int32, np.int64)):
+        return int(obj)
+    elif isinstance(obj, dict):
+        return {k: make_json_safe(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [make_json_safe(v) for v in obj]
+    else:
+        return obj
+
+
+def load_combined_results() -> pd.DataFrame:
+    master_paths = glob.glob("rpscrape/data/regions/gb/*/2015-2025.csv") + glob.glob(
+        "rpscrape/data/regions/ire/*/2015-2025.csv"
+    )
+    master_frames = []
+    for path in master_paths:
+        try:
+            df = pd.read_csv(
+                path,
+                usecols=["date", "course", "off", "class", "horse"],
+                parse_dates=["date"],
+            )
+            master_frames.append(df)
+        except Exception:
+            continue
+    recent_paths = glob.glob("rpscrape/data/dates/all/*.csv")
+    recent_frames = []
+    for path in recent_paths:
+        try:
+            df = pd.read_csv(
+                path,
+                usecols=["date", "course", "off", "class", "horse"],
+                parse_dates=["date"],
+            )
+            recent_frames.append(df)
+        except Exception:
+            continue
+    combined = pd.concat(master_frames + recent_frames, ignore_index=True)
+    combined["horse_clean"] = (
+        combined["horse"]
+        .astype(str)
+        .str.lower()
+        .str.replace(r" \([A-Z]{2,3}\)", "", regex=True)
+        .str.strip()
+    )
+    combined["class_num"] = (
+        combined["class"].astype(str).str.extract(r"(\d+)").fillna(-1).astype(float)
+    )
+    combined = combined.dropna(subset=["date", "class_num"])
+    return combined
+
+
+def get_last_class(horse_name: str, today_date: date, combined_df: pd.DataFrame):
+    horse_key = (
+        str(horse_name).lower().strip().replace(" (IRE)", "").replace(" (GB)", "")
+    )
+    df = combined_df[combined_df["horse_clean"] == horse_key]
+    df = df[df["date"] < pd.Timestamp(today_date)]
+    if df.empty:
+        return None
+    return df.sort_values("date", ascending=False).iloc[0]["class_num"]
+
+
+def extract_race_sort_key(race: str) -> int:
+    try:
+        time_str, _course = race.split(maxsplit=1)
+        h, m = map(int, time_str.split(":"))
+        return h * 60 + m
+    except Exception:
+        return 9999
+
 
 def main() -> None:
     load_env()
@@ -63,78 +224,75 @@ def main() -> None:
         download_if_missing(bucket, model_arg, local_model_file)
         model_path = local_model_file
 
-    with tempfile.TemporaryDirectory() as model_dir:
-        with tarfile.open(model_path, "r:gz") as tar:
-            tar.extractall(model_dir)
+    model_dir = tempfile.mkdtemp()
+    with tarfile.open(model_path, "r:gz") as tar:
+        tar.extractall(model_dir)
 
-        model_file = os.path.join(model_dir, "tipping-monster-xgb-model.bst")
-        features_file = os.path.join(model_dir, "features.json")
+    model_file = os.path.join(model_dir, "tipping-monster-xgb-model.bst")
+    features_file = os.path.join(model_dir, "features.json")
 
-        model = xgb.XGBClassifier()
-        model.load_model(model_file)
+    model = xgb.XGBClassifier()
+    model.load_model(model_file)
 
-        # Load optional meta place model
-        meta_place_model = None
-        meta_feat_file = os.path.join(model_dir, "meta_place_features.json")
-        meta_model_file = os.path.join(model_dir, "meta_place_model.pkl")
-        if os.path.exists(meta_model_file) and os.path.exists(meta_feat_file):
-            with open(meta_model_file, "rb") as f:
-                meta_place_model = pickle.load(f)
-            with open(meta_feat_file) as f:
-                meta_place_features = json.load(f)
+    meta_place_model = None
+    meta_feat_file = os.path.join(model_dir, "meta_place_features.json")
+    meta_model_file = os.path.join(model_dir, "meta_place_model.pkl")
+    if os.path.exists(meta_model_file) and os.path.exists(meta_feat_file):
+        with open(meta_model_file, "rb") as f:
+            meta_place_model = pickle.load(f)
+        with open(meta_feat_file) as f:
+            meta_place_features = json.load(f)
+    else:
+        meta_place_features = []
+
+    with open(input_path) as f:
+        rows = [json.loads(line) for line in f]
+    df = pd.DataFrame(rows)
+
+    model_features = list(df.columns)
+    if os.path.exists(features_file):
+        with open(features_file) as f:
+            model_features = json.load(f)
+
+    missing = [f for f in model_features if f not in df.columns]
+    if missing:
+        print(f"❌ Feature mismatch. Missing: {missing}")
+        sys.exit(1)
+
+    X = df[model_features]
+    X = X.apply(pd.to_numeric, errors="coerce").fillna(-1)
+
+    df["confidence"] = model.predict_proba(X)[:, 1]
+
+    if meta_place_model and meta_place_features:
+        missing_meta = [f for f in meta_place_features if f not in df.columns]
+        if missing_meta:
+            print(f"❌ Place feature mismatch. Missing: {missing_meta}")
         else:
-            meta_place_features = []
+            X_place = df[meta_place_features]
+            X_place = X_place.apply(pd.to_numeric, errors="coerce").fillna(-1)
+            df["final_place_confidence"] = meta_place_model.predict_proba(X_place)[:, 1]
+    top_tips = df.sort_values("confidence", ascending=False).groupby("race").head(1)
 
-        with open(input_path) as f:
-            rows = [json.loads(line) for line in f]
-        df = pd.DataFrame(rows)
+    top_tips["sort_key"] = top_tips["race"].apply(extract_race_sort_key)
+    top_tips = top_tips.sort_values("sort_key").drop(columns="sort_key")
 
-        model_features = list(df.columns)
-        if os.path.exists(features_file):
-            with open(features_file) as f:
-                model_features = json.load(f)
+    combined_results_df = load_combined_results()
+    today_date = datetime.today().date()
 
-        missing = [f for f in model_features if f not in df.columns]
-        if missing:
-            print(f"❌ Feature mismatch. Missing: {missing}")
-            sys.exit(1)
+    with open(output_path, "w") as f:
+        max_conf = top_tips["confidence"].max()
+        for row in top_tips.to_dict(orient="records"):
+            row["last_class"] = get_last_class(
+                row["name"], today_date, combined_results_df
+            )
+            row["global_max_confidence"] = max_conf
+            row["tags"] = generate_tags(row)
+            row["commentary"] = generate_reason(row)
+            row_safe = make_json_safe(row)
+            f.write(orjson.dumps(row_safe).decode() + "\n")
 
-        X = df[model_features]
-        X = X.apply(pd.to_numeric, errors="coerce").fillna(-1)
-
-        df["confidence"] = model.predict_proba(X)[:, 1]
-
-        # Generate final_place_confidence if meta place model is available
-        if meta_place_model and meta_place_features:
-            missing_meta = [f for f in meta_place_features if f not in df.columns]
-            if missing_meta:
-                print(f"❌ Place feature mismatch. Missing: {missing_meta}")
-            else:
-                X_place = df[meta_place_features]
-                X_place = X_place.apply(pd.to_numeric, errors="coerce").fillna(-1)
-                df["final_place_confidence"] = meta_place_model.predict_proba(X_place)[:, 1]
-
-        top_tips = df.sort_values("confidence", ascending=False).groupby("race").head(1)
-
-        top_tips["sort_key"] = top_tips["race"].apply(extract_race_sort_key)
-        top_tips = top_tips.sort_values("sort_key").drop(columns="sort_key")
-
-        combined_results_df = load_combined_results()
-        today_date = datetime.today().date()
-
-        with open(output_path, "w") as f:
-            max_conf = top_tips["confidence"].max()
-            for row in top_tips.to_dict(orient="records"):
-                row["last_class"] = get_last_class(
-                    row["name"], today_date, combined_results_df
-                )
-                row["global_max_confidence"] = max_conf
-                row["tags"] = generate_tags(row)
-                row["commentary"] = generate_reason(row)
-                row_safe = make_json_safe(row)
-                f.write(orjson.dumps(row_safe).decode() + "\n")
-
-        print(f"Saved {len(top_tips)} top tips to {output_path}")
+    print(f"Saved {len(top_tips)} top tips to {output_path}")
 
     if os.getenv("TM_DEV_MODE") == "1":
         print(f"[DEV] Skipping S3 upload of {output_path}")


### PR DESCRIPTION
## Summary
- document v8 stacked ensemble usage in README and quickstart
- note run_inference_monster_v8 in Docs index and model storage guidance
- restore helper functions in run_inference_and_select_top1
- clarify training command for v8 stack

## Testing
- `pre-commit run --files README.md Docs/quickstart.md Docs/CHANGELOG.md codex_log.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6f254a908324aebe00d711258194