### PR TITLE
Fix pipeline script ending

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -765,3 +765,8 @@
 - Removed duplicate meta place model lines in overview and todo.
 - Clarified planned stable-level intent profiler in overview.
 
+
+## 2025-07-24
+
+### Fixed
+- Restored missing lines in `run_pipeline_with_venv.sh` after S3 upload step and added cleanup exit.

--- a/codex_log.md
+++ b/codex_log.md
@@ -633,3 +633,8 @@ error. Added tests for failing responses and documented in changelog.
 **Prompt:** Address PR feedback about duplicate meta place model description and clarify trainer intent profiler status.
 **Files Changed:** Docs/monster_overview.md Docs/monster_todo.md Docs/CHANGELOG.md codex_log.md
 **Outcome:** Removed duplicate lines and updated overview bullet for planned stable-level profiler.
+
+## [2025-07-24] Fix truncated pipeline script
+**Prompt:** Ensure lines after S3 upload commands are complete and add cleanup.
+**Files Changed:** core/run_pipeline_with_venv.sh, Docs/CHANGELOG.md, codex_log.md
+**Outcome:** Script now properly closes S3 section, deactivates venv, and exits cleanly.

--- a/core/run_pipeline_with_venv.sh
+++ b/core/run_pipeline_with_venv.sh
@@ -94,5 +94,14 @@ if [ "$DEV_MODE" -eq 0 ]; then
     if command -v aws >/dev/null; then
         echo "🗂️ Uploading tips and logs to S3..."
         aws s3 cp "$SENT_TIPS_PATH" s3://tipping-monster/sent_tips/ --only-show-errors
-        aws s3 cp "$REPO_ROOT/logs/roi/tips_results_${TODAY}_advised.csv" s3://tipping-monster](#)
-
+        aws s3 cp "$REPO_ROOT/logs/roi/tips_results_${TODAY}_advised.csv" s3://tipping-monster/results/ --only-show-errors
+    else
+        echo "⚠️ AWS CLI not found, skipping S3 uploads"
+    fi
+else
+    echo "[DEV] Skipping S3 uploads"
+fi
+
+deactivate
+echo "✅ Pipeline complete: $(date)"
+exit 0


### PR DESCRIPTION
## Summary
- repair S3 upload section in `run_pipeline_with_venv.sh`
- add cleanup and exit
- document fix in CHANGELOG and codex_log

## Testing
- `pre-commit run --files core/run_pipeline_with_venv.sh Docs/CHANGELOG.md codex_log.md`
- `pytest -k run_pipeline_with_venv -q`

------
https://chatgpt.com/codex/tasks/task_e_684d92a9d7c08324b06a8deb7e8ffd75