### PR TITLE
Document dependencies install

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -765,3 +765,9 @@
 - Removed duplicate meta place model lines in overview and todo.
 - Clarified planned stable-level intent profiler in overview.
 
+## 2025-07-24
+
+### Documentation
+- README clarifies to install dependencies with `pip install -r requirements.txt` before running tests.
+- Added `scripts/install_requirements.sh` helper script.
+

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ Optionally, set `TIPPING_MONSTER_HOME` to the repository root:
 source utils/set_tm_home.sh
 ```
 
-4. Run tests to confirm everything is working:
+4. Run tests to confirm everything is working. Install dependencies first if you skipped step 1:
 
 ```bash
+pip install -r requirements.txt
 pytest
 ```
 

--- a/codex_log.md
+++ b/codex_log.md
@@ -633,3 +633,8 @@ error. Added tests for failing responses and documented in changelog.
 **Prompt:** Address PR feedback about duplicate meta place model description and clarify trainer intent profiler status.
 **Files Changed:** Docs/monster_overview.md Docs/monster_todo.md Docs/CHANGELOG.md codex_log.md
 **Outcome:** Removed duplicate lines and updated overview bullet for planned stable-level profiler.
+
+## [2025-07-24] Document install step before tests
+**Prompt:** Document running `pip install -r requirements.txt` before running tests and provide optional setup script.
+**Files Changed:** README.md scripts/install_requirements.sh Docs/CHANGELOG.md codex_log.md
+**Outcome:** README emphasises installing dependencies prior to tests and new helper script created.

--- a/scripts/install_requirements.sh
+++ b/scripts/install_requirements.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Install Python dependencies for Tipping Monster
+set -euo pipefail
+
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- remind developers to install Python dependencies before running tests
- add optional script to install dependencies
- update changelog and codex logs

## Testing
- `pre-commit run --files README.md scripts/install_requirements.sh Docs/CHANGELOG.md codex_log.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d92b0d028832486f96f7970097679