### PR TITLE
Update commentary doc references

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -765,3 +765,10 @@
 - Removed duplicate meta place model lines in overview and todo.
 - Clarified planned stable-level intent profiler in overview.
 
+## 2025-07-24
+
+### Documentation
+- Explicitly note the commentary script is proprietary and not included.
+- Removed disabled commentary lines from cron and pipeline docs.
+- Cleaned `run_pipeline_with_venv.sh` of stale commentary references.
+

--- a/Docs/monster_overview.md
+++ b/Docs/monster_overview.md
@@ -12,7 +12,7 @@ These core functionalities are currently **deployed and operating seamlessly** w
 * ✅ Confidence-based XGBoost ML model for tip generation
 * ✅ Odds integration (Betfair snapshot)
 * ✅ Tagging (e.g. Class Drop, In Form)
-* (Optional) LLM commentary generation – script not included
+* (Optional) LLM commentary generation – **proprietary script not included**
 * ✅ Tag-based commentary generation (ML-driven)
 * ✅ LLM commentary generation (optional)
 * ✅ Realistic odds injection
@@ -73,7 +73,6 @@ The system defines 8 core product layers:
 | 08:09 | `generate_lay_candidates.py`      | Flags favourites with low Monster confidence |
 | 08:10 | `dispatch_danger_favs.py`         | Sends Danger Fav alerts to Telegram |
 | 08:10 | `export_lay_candidates_csv.py`    | Saves Danger Fav CSV summary |
-| 08:11 | *(disabled)* `generate_commentary_bedrock.py` | Optional commentary step – script not included |
 | 08:12 | `core/dispatch_tips.py`           | Sends formatted tips to Telegram                       |
 | 08:13 | `generate_combos.py`              | Suggests doubles & trebles from top tips               |
 | 23:30 | `rpscrape` (results cron)    | Gets results for today’s races                         |
@@ -258,12 +257,12 @@ The foundational elements and automated processes that power Tipping Monster are
     * **`08:00`**: Fetch Betfair odds
     * **`08:05`**: Run ML inference
     * **`08:08`**: Merge tips with odds
-    * **`08:10`**: *(disabled)* Add LLM commentary – script not included
     * **`08:12`**: Dispatch tips to Telegram
     * **`23:30`**: Upload race results
     * **`23:55`**: Run ROI tracker
     * **`23:59`**: Send ROI summary to Telegram
     * **`23:56`**: Track bankroll and cumulative profit
+    * *(optional)* Generate commentary – **proprietary script not included**
 * **Centralized Logging:** All system logs are meticulously saved under the `/logs/*.log` directory for easy monitoring and debugging.
 * **Automated S3 Backups:** Daily backup to S3 at `02:10 AM` using `utils/backup_to_s3.sh`.
     * **Retention Policy:** Lifecycle rule ensures auto-deletion of backups older than **30 days**.

--- a/Docs/quickstart.md
+++ b/Docs/quickstart.md
@@ -35,7 +35,6 @@ A typical daily pipeline runs the following steps:
 08:00  core/fetch_betfair_odds.py      # Capture odds snapshot
 08:05  python -m core.run_inference_and_select_top1  # Predict and select tips
 08:08  core/merge_odds_into_tips.py    # Attach odds to tips
-08:10  [disabled] generate_commentary_bedrock.py  # Script not included
 08:12  core/dispatch_tips.py           # Send tips to Telegram
 08:13  generate_combos.py              # Suggest Monster doubles/trebles
 23:30  rpscrape (results cron)         # Get results for today
@@ -43,6 +42,7 @@ A typical daily pipeline runs the following steps:
 23:59  roi/send_daily_roi_summary.py  # Telegram summary of ROI
 ```
 These times are detailed in `Docs/monster_overview.md`.
+*Note:* An optional commentary step exists, but the script is **proprietary and not included**.
 
 ## Key Scripts
 

--- a/codex_log.md
+++ b/codex_log.md
@@ -633,3 +633,8 @@ error. Added tests for failing responses and documented in changelog.
 **Prompt:** Address PR feedback about duplicate meta place model description and clarify trainer intent profiler status.
 **Files Changed:** Docs/monster_overview.md Docs/monster_todo.md Docs/CHANGELOG.md codex_log.md
 **Outcome:** Removed duplicate lines and updated overview bullet for planned stable-level profiler.
+
+## [2025-07-24] Document proprietary commentary script
+**Prompt:** State explicitly that the optional commentary script is proprietary and remove old pipeline references.
+**Files Changed:** Docs/monster_overview.md Docs/quickstart.md core/run_pipeline_with_venv.sh Docs/CHANGELOG.md codex_log.md
+**Outcome:** Docs note the missing proprietary script and pipeline steps no longer reference it.

--- a/core/run_pipeline_with_venv.sh
+++ b/core/run_pipeline_with_venv.sh
@@ -57,12 +57,7 @@ echo "🧠 Running model inference..."
 echo "🔗 Merging tips with odds..."
 .venv/bin/python core/merge_odds_into_tips.py >> "$LOG_DIR/merge.log" 2>&1
 
-# 6. (Optional) Generate commentary
-# NOTE: The commentary script (`generate_commentary_bedrock.py`) is not included
-# in this repository. The call is disabled to avoid errors in the daily cron.
-# .venv/bin/python generate_commentary_bedrock.py >> "$LOG_DIR/commentary.log" 2>&1
-
-# 7. Dispatch tips to Telegram
+# 6. Dispatch tips to Telegram
 echo "🚀 Dispatching tips to Telegram..."
 TODAY=$(date +%F)
 DISPATCH_LOG="$LOG_DIR/dispatch/dispatch_${TODAY}.log"


### PR DESCRIPTION
## Summary
- clarify that the commentary script is proprietary and omitted
- remove disabled commentary call from `run_pipeline_with_venv.sh`
- clean pipeline tables referencing the script
- document the change in CHANGELOG and codex log

## Testing
- `pre-commit run --files core/run_pipeline_with_venv.sh Docs/monster_overview.md Docs/quickstart.md Docs/CHANGELOG.md codex_log.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d92b8136483249ef0b2233d85a704