### PR TITLE
Improve CSV error handling in run_inference

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -765,3 +765,9 @@
 - Removed duplicate meta place model lines in overview and todo.
 - Clarified planned stable-level intent profiler in overview.
 
+## 2025-07-24
+
+### Fixed
+- CSV loading errors in `run_inference_and_select_top1.py` now report the file
+  path and only catch parsing-related issues.
+

--- a/codex_log.md
+++ b/codex_log.md
@@ -633,3 +633,8 @@ error. Added tests for failing responses and documented in changelog.
 **Prompt:** Address PR feedback about duplicate meta place model description and clarify trainer intent profiler status.
 **Files Changed:** Docs/monster_overview.md Docs/monster_todo.md Docs/CHANGELOG.md codex_log.md
 **Outcome:** Removed duplicate lines and updated overview bullet for planned stable-level profiler.
+
+## [2025-07-24] Handle CSV parse failures in run_inference_and_select_top1
+**Prompt:** Replace generic exception handling with specific pandas errors and log the file path.
+**Files Changed:** core/run_inference_and_select_top1.py Docs/CHANGELOG.md codex_log.md
+**Outcome:** Script now warns which CSV failed to load and avoids hiding unrelated errors.

--- a/core/run_inference_and_select_top1.py
+++ b/core/run_inference_and_select_top1.py
@@ -4,6 +4,7 @@
 import argparse
 import glob
 import json
+import logging
 import os
 import pickle
 import sys
@@ -23,6 +24,9 @@ import xgboost as xgb
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from core.model_fetcher import download_if_missing
 from tippingmonster.env_loader import load_env
+
+logger = logging.getLogger(__name__)
+
 
 def generate_reason(tip: dict) -> str:
     reason = []
@@ -137,7 +141,8 @@ def load_combined_results() -> pd.DataFrame:
                 parse_dates=["date"],
             )
             master_frames.append(df)
-        except Exception:
+        except (FileNotFoundError, pd.errors.ParserError) as exc:
+            logger.warning("Failed to load %s: %s", path, exc)
             continue
     recent_paths = glob.glob("rpscrape/data/dates/all/*.csv")
     recent_frames = []
@@ -149,7 +154,8 @@ def load_combined_results() -> pd.DataFrame:
                 parse_dates=["date"],
             )
             recent_frames.append(df)
-        except Exception:
+        except (FileNotFoundError, pd.errors.ParserError) as exc:
+            logger.warning("Failed to load %s: %s", path, exc)
             continue
     combined = pd.concat(master_frames + recent_frames, ignore_index=True)
     combined["horse_clean"] = (
@@ -185,7 +191,9 @@ def extract_race_sort_key(race: str) -> int:
     except Exception:
         return 9999
 
+
 def main() -> None:
+    logging.basicConfig(level=logging.INFO)
     load_env()
 
     models = sorted(glob.glob("tipping-monster-xgb-model-*.tar.gz"))


### PR DESCRIPTION
## Summary
- handle CSV parse errors specifically in `run_inference_and_select_top1.py`
- warn which file failed when loading combined results
- document the change

## Testing
- `isort core/run_inference_and_select_top1.py`
- `black core/run_inference_and_select_top1.py`
- `flake8 core/run_inference_and_select_top1.py`
- `pytest tests/test_run_inference_and_select_top1.py::test_run_inference_selects_top_tip -q`
- `pre-commit run --files core/run_inference_and_select_top1.py Docs/CHANGELOG.md codex_log.md`

------
https://chatgpt.com/codex/tasks/task_e_684d939952488324ab005a6fb0810a18